### PR TITLE
Add frontend lint/format tooling and pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+pnpm --dir frontend lint-staged

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,42 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  { ignores: ['dist'] },
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+    },
+  },
+  {
+    files: ['src/**/*.{tsx,jsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'warn',
+        {
+          patterns: [
+            {
+              group: ['**/domain/**'],
+              message:
+                'Keep domain logic out of React components; use application-layer adapters.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,24 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.node.json"
+    "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.node.json",
+    "lint": "eslint .",
+    "format": "prettier . --write",
+    "format:check": "prettier . --check",
+    "lint-staged": "lint-staged",
+    "prepare": "husky ../.husky"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{css,json,md}": "prettier --write"
+  },
+  "prettier": {
+    "semi": true,
+    "singleQuote": true,
+    "trailingComma": "all"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -17,7 +34,16 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.1",
+    "@eslint/js": "^9.9.0",
+    "eslint": "^9.9.0",
+    "eslint-plugin-react-hooks": "^5.1.0-rc.0",
+    "eslint-plugin-react-refresh": "^0.4.11",
+    "globals": "^15.9.0",
+    "husky": "^9.1.5",
+    "lint-staged": "^15.2.10",
+    "prettier": "^3.3.3",
     "typescript": "^5.5.4",
+    "typescript-eslint": "^8.3.0",
     "vite": "^5.3.4"
   }
 }


### PR DESCRIPTION
### Motivation

- Add a pragmatic lint/format toolchain to the frontend to reduce styling and lint regressions. 
- Ensure staged files are automatically lint-fixed and formatted before commits via a pre-commit hook. 
- Provide a lightweight guardrail to discourage importing domain logic into React components.

### Description

- Update `frontend/package.json` to add scripts (`lint`, `format`, `format:check`, `lint-staged`, `prepare`), `lint-staged` and `prettier` configuration, and necessary devDependencies. 
- Add `frontend/eslint.config.js` as a minimal flat ESLint config for React + TypeScript and include a `no-restricted-imports` warning for `**/domain/**`. 
- Add workspace-root `.husky/pre-commit` hook that runs `pnpm --dir frontend lint-staged` to enforce the staged-file checks.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c35edbb5c8326a44017b831a6688c)