### PR TITLE
Add task contract schema and validation tests

### DIFF
--- a/frontend/src/contracts/index.ts
+++ b/frontend/src/contracts/index.ts
@@ -1,4 +1,5 @@
 import bedSchema from './bed.schema.json';
 import cropSchema from './crop.schema.json';
+import taskSchema from './task.schema.json';
 
-export { bedSchema, cropSchema };
+export { bedSchema, cropSchema, taskSchema };

--- a/frontend/src/contracts/task.schema.json
+++ b/frontend/src/contracts/task.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://survivalgarden/contracts/task.schema.json",
+  "title": "Task",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "sourceKey",
+    "date",
+    "type",
+    "cropId",
+    "bedId",
+    "batchId",
+    "checklist",
+    "status"
+  ],
+  "properties": {
+    "id": {
+      "$ref": "#/$defs/id"
+    },
+    "sourceKey": {
+      "$ref": "#/$defs/id"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "type": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80
+    },
+    "cropId": {
+      "$ref": "#/$defs/id"
+    },
+    "bedId": {
+      "$ref": "#/$defs/id"
+    },
+    "batchId": {
+      "$ref": "#/$defs/id"
+    },
+    "checklist": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80
+    }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    }
+  }
+}

--- a/frontend/src/contracts/task.schema.test.ts
+++ b/frontend/src/contracts/task.schema.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import Ajv2020 from 'ajv/dist/2020';
+import taskSchema from './task.schema.json';
+
+describe('task.schema.json', () => {
+  const ajv = new Ajv2020({ strict: true });
+  const validate = ajv.compile(taskSchema);
+
+  const validPayload = {
+    id: 'task_001',
+    sourceKey: 'batch_2026-03-01_crop_tomato_bed_001_water',
+    date: '2026-03-01',
+    type: 'water',
+    cropId: 'crop_tomato',
+    bedId: 'bed_001',
+    batchId: 'batch_2026_03',
+    checklist: [{ label: 'Water thoroughly', done: false }],
+    status: 'pending',
+  };
+
+  it('accepts a valid Task payload', () => {
+    expect(validate(validPayload)).toBe(true);
+  });
+
+  it('rejects payloads missing required fields', () => {
+    const { status, ...payload } = validPayload;
+
+    expect(status).toBeDefined();
+    expect(validate(payload)).toBe(false);
+  });
+
+  it('rejects invalid date format', () => {
+    const payload = {
+      ...validPayload,
+      date: '2026-03-01T00:00:00Z',
+    };
+
+    expect(validate(payload)).toBe(false);
+  });
+
+  it('accepts regenerated payload shape with stable sourceKey and updated status', () => {
+    const payload = {
+      ...validPayload,
+      status: 'completed',
+      checklist: [{ label: 'Water thoroughly', done: true }],
+    };
+
+    expect(payload.sourceKey).toBe(validPayload.sourceKey);
+    expect(validate(payload)).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation
- Introduce a formal JSON Schema for Task payloads so generated tasks validate consistently across consumers.  
- Ensure idempotent/regeneration semantics by including a stable `sourceKey` separate from `id` so regenerated tasks can be merged/updated.  
- Enforce a local-date representation (`YYYY-MM-DD`) for `date` to avoid timestamp/timezone ambiguity while keeping changes contract-only.

### Description
- Add `frontend/src/contracts/task.schema.json` defining a strict Draft-2020-12 object with `additionalProperties: false` and required fields `id`, `sourceKey`, `date`, `type`, `cropId`, `bedId`, `batchId`, `checklist`, and `status`.  
- Use a `date` property pattern of `^\d{4}-\d{2}-\d{2}$` and a shared `$defs/id` (string 1..128) to match existing contract conventions.  
- Add `frontend/src/contracts/task.schema.test.ts` using `Ajv2020` + `vitest` that covers a valid payload, missing required field rejection, invalid date format rejection, and a regeneration/update-friendly payload with stable `sourceKey` and updated `status`/`checklist`.  
- Export the new schema from `frontend/src/contracts/index.ts` as `taskSchema` for consumers to import.

### Testing
- Added an automated test file `frontend/src/contracts/task.schema.test.ts` that uses `Ajv2020` and `vitest` and includes four validation cases described above.  
- No automated tests were executed in this patch (no test runner invoked in the PR); run `pnpm vitest` locally or in CI to execute the new tests (they are expected to pass).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c696c8c508326b2453a7d1dc58bee)