### PR TITLE
Add MVP app-state schemas for CropPlan, SeedInventoryItem, and Settings with Ajv tests and exports

### DIFF
--- a/frontend/src/contracts/appstate.schema.test.ts
+++ b/frontend/src/contracts/appstate.schema.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import Ajv2020 from 'ajv/dist/2020';
+import cropPlanSchema from './crop-plan.schema.json';
+import seedInventoryItemSchema from './seed-inventory-item.schema.json';
+import settingsSchema from './settings.schema.json';
+
+describe('appstate-related schemas', () => {
+  const ajv = new Ajv2020({ strict: true });
+
+  it('accepts a valid CropPlan payload', () => {
+    const validate = ajv.compile(cropPlanSchema);
+    const payload = {
+      planId: 'plan_001',
+      cropId: 'crop_tomato',
+      bedId: 'bed_001',
+      seasonYear: 2026,
+      plannedWindows: {
+        sowing: [{ startMonth: 3, startWeek: 1, endMonth: 3, endWeek: 4 }],
+        transplant: [{ startMonth: 4, startWeek: 2, endMonth: 5, endWeek: 1 }],
+        harvest: [{ startMonth: 7, startWeek: 1, endMonth: 9, endWeek: 4 }],
+      },
+      expectedYield: {
+        amount: 5,
+        unit: 'kg',
+      },
+    };
+
+    expect(validate(payload)).toBe(true);
+  });
+
+  it('rejects CropPlan payload with invalid window fields', () => {
+    const validate = ajv.compile(cropPlanSchema);
+    const payload = {
+      planId: 'plan_001',
+      cropId: 'crop_tomato',
+      seasonYear: 2026,
+      plannedWindows: {
+        sowing: [{ startMonth: 0, startWeek: 1, endMonth: 3, endWeek: 4 }],
+        harvest: [{ startMonth: 7, startWeek: 1, endMonth: 9, endWeek: 4 }],
+      },
+      expectedYield: {
+        amount: 5,
+        unit: 'kg',
+      },
+    };
+
+    expect(validate(payload)).toBe(false);
+  });
+
+  it('accepts a valid SeedInventoryItem payload', () => {
+    const validate = ajv.compile(seedInventoryItemSchema);
+    const payload = {
+      seedInventoryItemId: 'seed_item_001',
+      cropId: 'crop_carrot',
+      variety: 'Nantes',
+      supplier: 'Seed Coop',
+      lotNumber: 'LOT-2026-01',
+      quantity: 120,
+      unit: 'seeds',
+      purchaseDate: '2026-01-05T00:00:00Z',
+      expiryDate: '2027-01-05T00:00:00Z',
+      status: 'available',
+      storageLocation: 'Pantry shelf',
+      createdAt: '2026-01-05T00:00:00Z',
+      updatedAt: '2026-02-01T00:00:00Z',
+    };
+
+    expect(validate(payload)).toBe(true);
+  });
+
+  it('rejects SeedInventoryItem payload with invalid status', () => {
+    const validate = ajv.compile(seedInventoryItemSchema);
+    const payload = {
+      seedInventoryItemId: 'seed_item_001',
+      cropId: 'crop_carrot',
+      variety: 'Nantes',
+      quantity: 120,
+      unit: 'seeds',
+      status: 'in_stock',
+      createdAt: '2026-01-05T00:00:00Z',
+      updatedAt: '2026-02-01T00:00:00Z',
+    };
+
+    expect(validate(payload)).toBe(false);
+  });
+
+  it('accepts a valid Settings payload', () => {
+    const validate = ajv.compile(settingsSchema);
+    const payload = {
+      settingsId: 'settings_001',
+      locale: 'de-DE',
+      timezone: 'Europe/Berlin',
+      weekStartsOn: 'monday',
+      units: {
+        temperature: 'celsius',
+        yield: 'metric',
+      },
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-10T00:00:00Z',
+    };
+
+    expect(validate(payload)).toBe(true);
+  });
+
+  it('rejects Settings payload with non-Berlin timezone', () => {
+    const validate = ajv.compile(settingsSchema);
+    const payload = {
+      settingsId: 'settings_001',
+      locale: 'de-DE',
+      timezone: 'UTC',
+      units: {
+        temperature: 'celsius',
+        yield: 'metric',
+      },
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-10T00:00:00Z',
+    };
+
+    expect(validate(payload)).toBe(false);
+  });
+});

--- a/frontend/src/contracts/crop-plan.schema.json
+++ b/frontend/src/contracts/crop-plan.schema.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://survivalgarden/contracts/crop-plan.schema.json",
+  "title": "CropPlan",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "planId",
+    "cropId",
+    "seasonYear",
+    "plannedWindows",
+    "expectedYield"
+  ],
+  "properties": {
+    "planId": {
+      "$ref": "#/$defs/id"
+    },
+    "cropId": {
+      "$ref": "#/$defs/id"
+    },
+    "bedId": {
+      "$ref": "#/$defs/id"
+    },
+    "seasonYear": {
+      "type": "integer",
+      "minimum": 2000,
+      "maximum": 2100
+    },
+    "plannedWindows": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sowing",
+        "harvest"
+      ],
+      "properties": {
+        "sowing": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/windowRange"
+          }
+        },
+        "transplant": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/windowRange"
+          }
+        },
+        "harvest": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/windowRange"
+          }
+        }
+      }
+    },
+    "expectedYield": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "amount",
+        "unit"
+      ],
+      "properties": {
+        "amount": {
+          "type": "number",
+          "minimum": 0
+        },
+        "unit": {
+          "type": "string",
+          "enum": [
+            "g",
+            "kg",
+            "pieces"
+          ]
+        }
+      }
+    },
+    "notes": {
+      "type": "string",
+      "maxLength": 500
+    }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "windowRange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "startMonth",
+        "startWeek",
+        "endMonth",
+        "endWeek"
+      ],
+      "properties": {
+        "startMonth": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 12
+        },
+        "startWeek": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 5
+        },
+        "endMonth": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 12
+        },
+        "endWeek": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 5
+        }
+      }
+    }
+  }
+}

--- a/frontend/src/contracts/index.ts
+++ b/frontend/src/contracts/index.ts
@@ -1,5 +1,15 @@
 import bedSchema from './bed.schema.json';
+import cropPlanSchema from './crop-plan.schema.json';
 import cropSchema from './crop.schema.json';
+import seedInventoryItemSchema from './seed-inventory-item.schema.json';
+import settingsSchema from './settings.schema.json';
 import taskSchema from './task.schema.json';
 
-export { bedSchema, cropSchema, taskSchema };
+export {
+  bedSchema,
+  cropPlanSchema,
+  cropSchema,
+  seedInventoryItemSchema,
+  settingsSchema,
+  taskSchema,
+};

--- a/frontend/src/contracts/seed-inventory-item.schema.json
+++ b/frontend/src/contracts/seed-inventory-item.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://survivalgarden/contracts/seed-inventory-item.schema.json",
+  "title": "SeedInventoryItem",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "seedInventoryItemId",
+    "cropId",
+    "variety",
+    "quantity",
+    "unit",
+    "status",
+    "createdAt",
+    "updatedAt"
+  ],
+  "properties": {
+    "seedInventoryItemId": {
+      "$ref": "#/$defs/id"
+    },
+    "cropId": {
+      "$ref": "#/$defs/id"
+    },
+    "variety": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 120
+    },
+    "supplier": {
+      "type": "string",
+      "maxLength": 120
+    },
+    "lotNumber": {
+      "type": "string",
+      "maxLength": 120
+    },
+    "quantity": {
+      "type": "number",
+      "minimum": 0
+    },
+    "unit": {
+      "type": "string",
+      "enum": [
+        "seeds",
+        "g",
+        "packets"
+      ]
+    },
+    "purchaseDate": {
+      "$ref": "#/$defs/isoDate"
+    },
+    "expiryDate": {
+      "$ref": "#/$defs/isoDate"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "available",
+        "low",
+        "depleted"
+      ]
+    },
+    "storageLocation": {
+      "type": "string",
+      "maxLength": 200
+    },
+    "notes": {
+      "type": "string",
+      "maxLength": 1000
+    },
+    "createdAt": {
+      "$ref": "#/$defs/isoDate"
+    },
+    "updatedAt": {
+      "$ref": "#/$defs/isoDate"
+    }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "isoDate": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?Z$"
+    }
+  }
+}

--- a/frontend/src/contracts/settings.schema.json
+++ b/frontend/src/contracts/settings.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://survivalgarden/contracts/settings.schema.json",
+  "title": "Settings",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "settingsId",
+    "locale",
+    "timezone",
+    "units",
+    "createdAt",
+    "updatedAt"
+  ],
+  "properties": {
+    "settingsId": {
+      "$ref": "#/$defs/id"
+    },
+    "locale": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 35,
+      "pattern": "^[a-z]{2}(?:-[A-Z]{2})?$"
+    },
+    "timezone": {
+      "type": "string",
+      "const": "Europe/Berlin"
+    },
+    "weekStartsOn": {
+      "type": "string",
+      "enum": [
+        "monday"
+      ]
+    },
+    "units": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "temperature",
+        "yield"
+      ],
+      "properties": {
+        "temperature": {
+          "type": "string",
+          "enum": [
+            "celsius"
+          ]
+        },
+        "yield": {
+          "type": "string",
+          "enum": [
+            "metric"
+          ]
+        }
+      }
+    },
+    "createdAt": {
+      "$ref": "#/$defs/isoDate"
+    },
+    "updatedAt": {
+      "$ref": "#/$defs/isoDate"
+    }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "isoDate": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?Z$"
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide AppState coverage needed for import/export and future .NET parity by adding missing domain schemas. 
- Keep schema style consistent with existing contracts (`$schema`, `$id`, `additionalProperties: false`, reusable `$defs`).
- Enforce explicit locale/timezone assumptions (Europe/Berlin) and minimal MVP fields for planning and seed export formats.

### Description
- Added `frontend/src/contracts/crop-plan.schema.json` implementing an MVP `CropPlan` with `plannedWindows` and `expectedYield` and a reusable `windowRange` definition. 
- Added `frontend/src/contracts/seed-inventory-item.schema.json` implementing `SeedInventoryItem` for export-ready inventory (identity, variety, quantity/unit, lifecycle metadata, status). 
- Added `frontend/src/contracts/settings.schema.json` implementing `Settings` including `locale`, `timezone` (const `Europe/Berlin`), `units`, and ISO datetime fields. 
- Exported the new schemas from `frontend/src/contracts/index.ts` and added consolidated Ajv/vitest validation tests in `frontend/src/contracts/appstate.schema.test.ts` covering positive and negative cases for all three schemas.

### Testing
- Added an automated test file `frontend/src/contracts/appstate.schema.test.ts` using `Ajv2020` + `vitest` with valid and invalid payloads for each new schema. 
- No automated tests were executed as part of this patch; CI or a local test run should execute the new `vitest` specs to verify runtime validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c6b42b940832698f152ab241f13fc)