### PR TITLE
test(frontend): validate golden fixtures and enforce canonical JSON order

### DIFF
--- a/frontend/src/contracts/appstate.schema.test.ts
+++ b/frontend/src/contracts/appstate.schema.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
 import Ajv2020 from 'ajv/dist/2020';
 import appStateSchema from './app-state.schema.json';
 import bedSchema from './bed.schema.json';
@@ -8,7 +10,51 @@ import seedInventoryItemSchema from './seed-inventory-item.schema.json';
 import settingsSchema from './settings.schema.json';
 import taskSchema from './task.schema.json';
 import type { AppState } from '../generated/contracts';
-import trierV1Fixture from '../../../fixtures/golden/trier-v1.json';
+
+const fixtureDir = path.resolve(import.meta.dirname, '../../../fixtures/golden');
+const fixturePaths = fs
+  .readdirSync(fixtureDir)
+  .filter((entry) => entry.endsWith('.json'))
+  .sort()
+  .map((entry) => path.join(fixtureDir, entry));
+
+const stableSortValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((item) => stableSortValue(item));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
+        .map(([key, nestedValue]) => [key, stableSortValue(nestedValue)]),
+    );
+  }
+
+  return value;
+};
+
+const toCanonicalJson = (value: unknown): string => `${JSON.stringify(stableSortValue(value), null, 2)}\n`;
+
+const formatAjvErrors = (errors: unknown): string => {
+  if (!Array.isArray(errors) || errors.length === 0) {
+    return 'Unknown schema validation error';
+  }
+
+  return errors
+    .map((error) => {
+      const instancePath =
+        error && typeof error === 'object' && 'instancePath' in error
+          ? String(error.instancePath || '/')
+          : '/';
+      const message = error && typeof error === 'object' && 'message' in error ? String(error.message) : 'invalid';
+      const params =
+        error && typeof error === 'object' && 'params' in error ? JSON.stringify(error.params) : '{}';
+
+      return `path=${instancePath} message=${message} details=${params}`;
+    })
+    .join('\n');
+};
 
 describe('AppState schema', () => {
   const buildValidator = () => {
@@ -153,9 +199,36 @@ describe('AppState schema', () => {
     expect(validate(payload)).toBe(false);
   });
 
-  it('accepts the golden trier-v1 fixture', () => {
+  it('accepts all golden fixtures', () => {
     const validate = buildValidator();
 
-    expect(validate(trierV1Fixture)).toBe(true);
+    expect(fixturePaths.length).toBeGreaterThan(0);
+
+    for (const fixturePath of fixturePaths) {
+      const fixtureText = fs.readFileSync(fixturePath, 'utf8');
+      const fixture = JSON.parse(fixtureText) as AppState;
+      const fixtureName = path.relative(fixtureDir, fixturePath);
+      const isValid = validate(fixture);
+
+      expect(
+        isValid,
+        `Fixture ${fixtureName} failed schema validation:\n${formatAjvErrors(validate.errors)}`,
+      ).toBe(true);
+    }
+  });
+
+  it('keeps golden fixtures key-sorted for stable diffs', () => {
+    for (const fixturePath of fixturePaths) {
+      const fixtureText = fs.readFileSync(fixturePath, 'utf8');
+      const parsedFixture = JSON.parse(fixtureText);
+      const canonicalFixture = toCanonicalJson(parsedFixture);
+      const fixtureName = path.relative(fixtureDir, fixturePath);
+
+      expect(
+        fixtureText,
+        `Fixture ${fixtureName} is not canonical JSON (sorted keys, 2-space indent, trailing newline).\n` +
+          `Run: node -e "const fs=require('fs');const p='${fixturePath.replace(/'/g, "\\'")}';const j=JSON.parse(fs.readFileSync(p,'utf8'));const s=(v)=>Array.isArray(v)?v.map(s):v&&typeof v==='object'?Object.fromEntries(Object.entries(v).sort(([a],[b])=>a.localeCompare(b)).map(([k,val])=>[k,s(val)])):v;fs.writeFileSync(p,JSON.stringify(s(j),null,2)+'\\n');"`,
+      ).toBe(canonicalFixture);
+    }
   });
 });


### PR DESCRIPTION
### Motivation
- Ensure all golden fixtures under `fixtures/golden/*.json` remain contract-valid and produce actionable failures when broken.
- Keep fixture files canonical (sorted object keys, 2-space indent, trailing newline) so diffs remain readable and PRs are small.

### Description
- Updated `frontend/src/contracts/appstate.schema.test.ts` to discover all `fixtures/golden/*.json` files at runtime and validate each with the existing AJV AppState validator.
- Added a small AJV error formatter that prints `instancePath`, message, and params for clearer per-fixture failure messages.
- Added a deterministic canonical JSON check using a stable key-sort + `JSON.stringify(..., null, 2) + '\n'` comparison and a one-liner fix command in the failure message.
- Kept changes limited to the existing test file to minimize churn (Option A from the plan).

### Testing
- No automated tests were executed locally as part of this patch; the new tests are standard Vitest tests and are placed under the existing test path so CI will run them.  If a fixture is invalid or unsorted the added tests will fail in CI with the provided actionable messages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c76bf773c83269bf8122067fdbffb)