### PR TITLE
fix(frontend): check canonical fixture formatting using raw file contents

### DIFF
--- a/frontend/src/contracts/appstate.schema.test.ts
+++ b/frontend/src/contracts/appstate.schema.test.ts
@@ -8,7 +8,55 @@ import seedInventoryItemSchema from './seed-inventory-item.schema.json';
 import settingsSchema from './settings.schema.json';
 import taskSchema from './task.schema.json';
 import type { AppState } from '../generated/contracts';
-import trierV1Fixture from '../../../fixtures/golden/trier-v1.json';
+
+const goldenFixtures = import.meta.glob('../../../fixtures/golden/*.json', {
+  eager: true,
+  import: 'default',
+}) as Record<string, AppState>;
+const goldenFixturesRaw = import.meta.glob('../../../fixtures/golden/*.json', {
+  eager: true,
+  query: '?raw',
+  import: 'default',
+}) as Record<string, string>;
+const fixturePaths = Object.keys(goldenFixtures).sort();
+
+const stableSortValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((item) => stableSortValue(item));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
+        .map(([key, nestedValue]) => [key, stableSortValue(nestedValue)]),
+    );
+  }
+
+  return value;
+};
+
+const toCanonicalJson = (value: unknown): string => `${JSON.stringify(stableSortValue(value), null, 2)}\n`;
+
+const formatAjvErrors = (errors: unknown): string => {
+  if (!Array.isArray(errors) || errors.length === 0) {
+    return 'Unknown schema validation error';
+  }
+
+  return errors
+    .map((error) => {
+      const instancePath =
+        error && typeof error === 'object' && 'instancePath' in error
+          ? String(error.instancePath || '/')
+          : '/';
+      const message = error && typeof error === 'object' && 'message' in error ? String(error.message) : 'invalid';
+      const params =
+        error && typeof error === 'object' && 'params' in error ? JSON.stringify(error.params) : '{}';
+
+      return `path=${instancePath} message=${message} details=${params}`;
+    })
+    .join('\n');
+};
 
 describe('AppState schema', () => {
   const buildValidator = () => {
@@ -153,9 +201,35 @@ describe('AppState schema', () => {
     expect(validate(payload)).toBe(false);
   });
 
-  it('accepts the golden trier-v1 fixture', () => {
+  it('accepts all golden fixtures', () => {
     const validate = buildValidator();
 
-    expect(validate(trierV1Fixture)).toBe(true);
+    expect(fixturePaths.length).toBeGreaterThan(0);
+
+    for (const fixturePath of fixturePaths) {
+      const fixture = goldenFixtures[fixturePath];
+      const fixtureName = fixturePath.replace('../../../fixtures/golden/', '');
+      const isValid = validate(fixture);
+
+      expect(
+        isValid,
+        `Fixture ${fixtureName} failed schema validation:\n${formatAjvErrors(validate.errors)}`,
+      ).toBe(true);
+    }
+  });
+
+  it('keeps golden fixtures key-sorted for stable diffs', () => {
+    for (const fixturePath of fixturePaths) {
+      const fixtureText = goldenFixturesRaw[fixturePath];
+      const parsedFixture = JSON.parse(fixtureText);
+      const canonicalFixture = toCanonicalJson(parsedFixture);
+      const fixtureName = fixturePath.replace('../../../fixtures/golden/', '');
+
+      expect(
+        fixtureText,
+        `Fixture ${fixtureName} is not canonical JSON (sorted keys, 2-space indent, trailing newline).\n` +
+          `Run: node -e "const fs=require('fs');const p='${fixturePath.replace(/'/g, "\\'")}';const j=JSON.parse(fs.readFileSync(p,'utf8'));const s=(v)=>Array.isArray(v)?v.map(s):v&&typeof v==='object'?Object.fromEntries(Object.entries(v).sort(([a],[b])=>a.localeCompare(b)).map(([k,val])=>[k,s(val)])):v;fs.writeFileSync(p,JSON.stringify(s(j),null,2)+'\\n');"`,
+      ).toBe(canonicalFixture);
+    }
   });
 });


### PR DESCRIPTION
### Motivation
- Ensure golden fixture formatting (key order, 2-space indent, trailing newline) is validated against the actual file contents instead of reconstructed JSON, which could hide formatting drift.
- Keep tests bundler-friendly and avoid Node-only APIs by using `import.meta.glob` to load fixtures in the frontend environment.

### Description
- Added a raw fixture import map using `import.meta.glob('../../../fixtures/golden/*.json', { query: '?raw', eager: true, import: 'default' })` in `frontend/src/contracts/appstate.schema.test.ts`.
- Updated the canonical-JSON test to compare the raw file text (`fixtureText`) against the computed canonical representation of the parsed JSON, and kept the schema validation loop to validate every golden fixture.
- Added a small `formatAjvErrors` helper to produce readable schema error messages for failing fixtures.

### Testing
- No automated tests were executed locally; the change modifies test behavior and will be validated by the repository `vitest` suite in CI.
- The updated test asserts `fixturePaths.length > 0` which will fail if no golden fixtures are discovered and the canonical-JSON assertion will fail if any fixture is not properly canonical formatted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c76bf773c83269bf8122067fdbffb)