### PR TITLE
Add ImportMeta.glob typing to appstate schema test

### DIFF
--- a/frontend/src/contracts/appstate.schema.test.ts
+++ b/frontend/src/contracts/appstate.schema.test.ts
@@ -1,3 +1,12 @@
+declare global {
+  interface ImportMeta {
+    glob: (
+      pattern: string,
+      options?: { eager?: boolean; import?: string },
+    ) => Record<string, unknown>;
+  }
+}
+
 import { describe, expect, it } from 'vitest';
 import Ajv2020 from 'ajv/dist/2020';
 import appStateSchema from './app-state.schema.json';


### PR DESCRIPTION
### Motivation
- Fix a TypeScript error where `import.meta.glob(...)` caused `TS2339: Property 'glob' does not exist on type 'ImportMeta'` in `frontend/src/contracts/appstate.schema.test.ts` during typechecking.

### Description
- Add a minimal global `ImportMeta` declaration to `frontend/src/contracts/appstate.schema.test.ts` that defines a `glob` signature with `pattern` and optional `options` returning `Record<string, unknown>`.
- The change is localized to the test file and does not alter runtime logic or fixture-loading code.

### Testing
- Ran `pnpm --filter frontend typecheck`, which exited with status 2 because the environment is missing frontend dependencies (`node_modules`), so the full typecheck failed; the added typing addresses the prior `ImportMeta.glob` error but the overall typecheck cannot complete here due to missing packages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c7e496cd48326a3f102d92fa54207)