### PR TITLE
Add AppState import/export roundtrip tests and document roundtrip boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ Deterministic IDs in golden fixtures use fixed prefixes with zero-padded sequenc
 - Settings: `settings_001`
 
 The current Bed schema has no dedicated area field, so approximate m² allocations are documented in each bed's `notes` field.
+
+## Import/export roundtrip boundaries
+
+Import/export is treated as lossless for all schema-defined `AppState` fields after canonical JSON normalization (stable key ordering before deep comparison).
+
+Photo/blob payload data is intentionally excluded from roundtrip guarantees. If photo metadata fields exist in schema, metadata must survive export → import → export, while blob payload paths (currently documented as `/photos/*/blob` and `/photos/*/blobBase64`) are excluded-by-design.

--- a/frontend/src/data/validation/index.test.ts
+++ b/frontend/src/data/validation/index.test.ts
@@ -3,8 +3,53 @@ import {
   SchemaValidationError,
   assertValid,
   parseImportedAppState,
+  serializeAppStateForExport,
   saveAppStateToStorage,
 } from '..';
+
+const goldenFixtures = import.meta.glob('../../../../fixtures/golden/*.json', {
+  eager: true,
+  import: 'default',
+}) as Record<string, unknown>;
+
+const pathSegmentWildcard = '*';
+const nonRoundtrippedPaths = ['/photos/*/blob', '/photos/*/blobBase64'];
+
+const pathMatches = (path: string, pattern: string): boolean => {
+  const pathParts = path.split('/').filter(Boolean);
+  const patternParts = pattern.split('/').filter(Boolean);
+
+  if (pathParts.length !== patternParts.length) {
+    return false;
+  }
+
+  return patternParts.every(
+    (patternPart, index) => patternPart === pathSegmentWildcard || patternPart === pathParts[index],
+  );
+};
+
+const canonicalizeForComparison = (value: unknown, path = '/'): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((item, index) => canonicalizeForComparison(item, `${path}${path.endsWith('/') ? '' : '/'}${index}`));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([key]) => {
+          const keyPath = `${path}${path.endsWith('/') ? '' : '/'}${key}`;
+          return !nonRoundtrippedPaths.some((pattern) => pathMatches(keyPath, pattern));
+        })
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nestedValue]) => {
+          const keyPath = `${path}${path.endsWith('/') ? '' : '/'}${key}`;
+          return [key, canonicalizeForComparison(nestedValue, keyPath)];
+        }),
+    );
+  }
+
+  return value;
+};
 
 describe('assertValid', () => {
   it('throws normalized validation issues for invalid appState payloads', () => {
@@ -85,5 +130,29 @@ describe('data boundary validation', () => {
       SchemaValidationError,
     );
     expect(setItem).not.toHaveBeenCalled();
+  });
+
+  it('roundtrips golden fixtures through export/import/export losslessly', () => {
+    const fixturePaths = Object.keys(goldenFixtures).sort();
+    expect(fixturePaths.length).toBeGreaterThan(0);
+
+    for (const fixturePath of fixturePaths) {
+      const fixture = goldenFixtures[fixturePath];
+      const firstExport = serializeAppStateForExport(fixture);
+      const imported = parseImportedAppState(firstExport);
+      const secondExport = serializeAppStateForExport(imported);
+
+      expect(canonicalizeForComparison(JSON.parse(secondExport))).toEqual(
+        canonicalizeForComparison(JSON.parse(firstExport)),
+      );
+    }
+  });
+
+  it('preserves photo metadata in roundtrip while excluding blob payload paths by design', () => {
+    const fixture = goldenFixtures['../../../../fixtures/golden/trier-v1.json'];
+    const exported = serializeAppStateForExport(fixture);
+    const imported = parseImportedAppState(exported);
+
+    expect(canonicalizeForComparison(imported)).toEqual(canonicalizeForComparison(JSON.parse(exported)));
   });
 });


### PR DESCRIPTION
### Motivation
- Ensure import/export roundtrips are stable and deterministic for `AppState` payloads to catch regressions in serialization/validation.
- Make canonical comparison resilient to non-roundtripped binary/blob fields so tests fail only on meaningful contract changes.
- Explicitly document the intended roundtrip contract for metadata vs blob payloads to set expectations for future schema evolution.

### Description
- Added roundtrip contract tests to `frontend/src/data/validation/index.test.ts` that load golden fixtures, run `serializeAppStateForExport` → `parseImportedAppState` → `serializeAppStateForExport`, and compare canonicalized JSON for deep equality while omitting configured blob paths.
- Implemented a local `canonicalizeForComparison()` helper in the test to perform stable key ordering and a narrow path-based omit list for `/photos/*/blob` and `/photos/*/blobBase64` so blob payloads are excluded-by-design.
- Added a focused photo metadata roundtrip assertion in the same test file to codify that metadata must survive the roundtrip while blob payloads are intentionally excluded.
- Updated `README.md` to document import/export roundtrip boundaries and the explicit exclusion of photo/blob payload paths.

### Testing
- Added `vitest` unit tests in `frontend/src/data/validation/index.test.ts` including `roundtrips golden fixtures through export/import/export losslessly` and a photo metadata roundtrip test; these tests have been committed but were not executed in this patch (FAST PATCH MODE).
- Local/CI should run the test suite (for example `vitest` or project test script) to validate the new tests; no automated test run was performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d664a81f48326b7574aba22fb7c7b)