### PR TITLE
Document identifier strategy and add deterministic task sourceKey helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 `frontend/src/contracts/app-state.schema.json` defines the import/export `AppState` envelope and requires a numeric `schemaVersion` (integer, minimum `1`) for migration gating between persisted schema revisions.
 
+## Identifier & key strategy
+
+- Use UUID v4 IDs (`crypto.randomUUID`) for user-authored entities created at runtime.
+- Use deterministic task `sourceKey` values for generated tasks via stable inputs: `batchId + date + cropId + bedId + type`.
+- Never assign random IDs/keys to generated tasks; generated task identity must remain idempotent across regenerations.
+- Golden fixture IDs like `task_001` remain deterministic test data and do not replace runtime UUID policy for user-authored entities.
+
 ## Golden dataset conventions
 
 `fixtures/golden/trier-v1.json` is the stable AppState reference fixture for workflow/idempotence checks.

--- a/frontend/src/contracts/task.schema.test.ts
+++ b/frontend/src/contracts/task.schema.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import Ajv2020 from 'ajv/dist/2020';
 import taskSchema from './task.schema.json';
+import { buildTaskSourceKey } from '../domain';
 
 describe('task.schema.json', () => {
   const ajv = new Ajv2020({ strict: true });
@@ -8,7 +9,13 @@ describe('task.schema.json', () => {
 
   const validPayload = {
     id: 'task_001',
-    sourceKey: 'batch_2026-03-01_crop_tomato_bed_001_water',
+    sourceKey: buildTaskSourceKey(
+      'batch',
+      '2026-03-01',
+      'crop_tomato',
+      'bed_001',
+      'water',
+    ),
     date: '2026-03-01',
     type: 'water',
     cropId: 'crop_tomato',
@@ -47,5 +54,25 @@ describe('task.schema.json', () => {
 
     expect(payload.sourceKey).toBe(validPayload.sourceKey);
     expect(validate(payload)).toBe(true);
+  });
+
+  it('builds deterministic sourceKey for identical task inputs', () => {
+    const sourceKeyA = buildTaskSourceKey(
+      'batch',
+      '2026-03-01',
+      'crop_tomato',
+      'bed_001',
+      'water',
+    );
+    const sourceKeyB = buildTaskSourceKey(
+      'batch',
+      '2026-03-01',
+      'crop_tomato',
+      'bed_001',
+      'water',
+    );
+
+    expect(sourceKeyA).toBe('batch_2026-03-01_crop_tomato_bed_001_water');
+    expect(sourceKeyB).toBe(sourceKeyA);
   });
 });

--- a/frontend/src/domain/index.ts
+++ b/frontend/src/domain/index.ts
@@ -1,1 +1,9 @@
-export {};
+export const createUuid = (): string => crypto.randomUUID();
+
+export const buildTaskSourceKey = (
+  batchId: string,
+  date: string,
+  cropId: string,
+  bedId: string,
+  type: string,
+): string => [batchId, date, cropId, bedId, type].join('_').toLowerCase();


### PR DESCRIPTION
### Motivation

- Ensure generated tasks are idempotent by using deterministic keys rather than random IDs.
- Clarify runtime ID policy to avoid accidental drift between regenerated tasks and golden fixtures.

### Description

- Add an `Identifier & key strategy` section to `README.md` documenting UUID v4 for user-authored entities and deterministic `sourceKey` construction for generated tasks. 
- Add minimal domain helpers in `frontend/src/domain/index.ts`: `createUuid()` (calls `crypto.randomUUID`) and `buildTaskSourceKey(batchId, date, cropId, bedId, type)` which returns a stable underscore-joined, lowercased key. 
- Update `frontend/src/contracts/task.schema.test.ts` to use `buildTaskSourceKey()` for constructing test payloads and add a unit assertion that identical inputs produce identical `sourceKey` values.

### Testing

- Added a unit assertion in `frontend/src/contracts/task.schema.test.ts` that verifies deterministic `sourceKey` generation for identical inputs, but this test was not executed in this patch. 
- No automated test runs were performed here due to the repository-level constraint: `No build/run/tests` (FAST PATCH MODE).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d6abd46e48326846c2b9256a4b4a4)