### PR TITLE
Add IndexedDB app state storage with migrations, init/error UI and reset

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,6 @@
+import { useCallback, useEffect, useState } from 'react';
 import { Navigate, NavLink, Route, Routes } from 'react-router-dom';
+import { AppStateStorageError, initializeAppStateStorage } from './data';
 
 function BedsPage() {
   return <p>Beds</p>;
@@ -20,7 +22,87 @@ function DataPage() {
   return <p>Data</p>;
 }
 
+const STORAGE_DB_NAME = 'survival-garden';
+
+const resetLocalData = async (): Promise<void> => {
+  if (typeof indexedDB === 'undefined') {
+    throw new AppStateStorageError('IndexedDB is not available in this environment.');
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const deleteRequest = indexedDB.deleteDatabase(STORAGE_DB_NAME);
+
+    deleteRequest.onsuccess = () => resolve();
+    deleteRequest.onerror = () => reject(new AppStateStorageError('Failed to reset local data storage.'));
+    deleteRequest.onblocked = () =>
+      reject(new AppStateStorageError('Close other SurvivalGarden tabs and try reset again.'));
+  });
+};
+
 function App() {
+  const [storageError, setStorageError] = useState<string | null>(null);
+  const [isInitializingStorage, setIsInitializingStorage] = useState(true);
+
+  const initializeStorage = useCallback(async () => {
+    setIsInitializingStorage(true);
+    setStorageError(null);
+
+    try {
+      await initializeAppStateStorage();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to initialize local data storage.';
+      setStorageError(message);
+    } finally {
+      setIsInitializingStorage(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void initializeStorage();
+  }, [initializeStorage]);
+
+  const handleReset = useCallback(async () => {
+    setIsInitializingStorage(true);
+
+    try {
+      await resetLocalData();
+      await initializeStorage();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to reset local data storage.';
+      setStorageError(message);
+      setIsInitializingStorage(false);
+    }
+  }, [initializeStorage]);
+
+  if (isInitializingStorage) {
+    return (
+      <div className="storage-error-screen" role="status" aria-live="polite">
+        <h1>Starting SurvivalGarden…</h1>
+        <p>Preparing local data storage.</p>
+      </div>
+    );
+  }
+
+  if (storageError) {
+    return (
+      <div className="storage-error-screen" role="alert">
+        <h1>Local storage unavailable</h1>
+        <p>{storageError}</p>
+        <p>Try again, or reset local data if migration is blocked or corrupted.</p>
+        <div className="storage-error-actions">
+          <button type="button" onClick={() => void initializeStorage()}>
+            Retry
+          </button>
+          <button type="button" onClick={() => void handleReset()}>
+            Reset local data
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="app-shell">
       <header className="app-header">

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -1,6 +1,13 @@
 import type { AppState } from '../contracts';
 import { assertValid } from './validation';
 
+const APP_STATE_DB_NAME = 'survival-garden';
+const APP_STATE_DB_VERSION = 2;
+const APP_STATE_STORE = 'appState';
+const APP_STATE_RECORD_KEY = 'current';
+const META_STORE = 'meta';
+const SCHEMA_VERSION_KEY = 'schemaVersion';
+
 export type {
   AppStateRepository,
   BedRepository,
@@ -53,4 +60,122 @@ export const saveAppStateToStorage = (
   appState: unknown,
 ): void => {
   storage.setItem(key, serializeAppStateForExport(appState));
+};
+
+export class AppStateStorageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AppStateStorageError';
+  }
+}
+
+const requestToPromise = <T>(request: IDBRequest<T>): Promise<T> =>
+  new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+
+const transactionDone = (transaction: IDBTransaction): Promise<void> =>
+  new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+    transaction.onabort = () => reject(transaction.error ?? new Error('IndexedDB transaction aborted.'));
+  });
+
+const migrateV1ToV2 = (database: IDBDatabase, transaction: IDBTransaction): void => {
+  if (!database.objectStoreNames.contains(META_STORE)) {
+    database.createObjectStore(META_STORE);
+  }
+
+  const metaStore = transaction.objectStore(META_STORE);
+  metaStore.put(2, SCHEMA_VERSION_KEY);
+};
+
+const openAppStateDatabase = async (): Promise<IDBDatabase> => {
+  if (typeof indexedDB === 'undefined') {
+    throw new AppStateStorageError('IndexedDB is not available in this environment.');
+  }
+
+  return new Promise((resolve, reject) => {
+    const openRequest = indexedDB.open(APP_STATE_DB_NAME, APP_STATE_DB_VERSION);
+
+    openRequest.onupgradeneeded = (event) => {
+      const database = openRequest.result;
+      const { transaction } = openRequest;
+
+      if (!transaction) {
+        throw new AppStateStorageError('IndexedDB migration transaction was not created.');
+      }
+
+      if (!database.objectStoreNames.contains(APP_STATE_STORE)) {
+        database.createObjectStore(APP_STATE_STORE);
+      }
+
+      if (event.oldVersion < 2) {
+        migrateV1ToV2(database, transaction);
+      }
+    };
+
+    openRequest.onblocked = () => {
+      reject(new AppStateStorageError('Local data storage upgrade is blocked by another browser tab.'));
+    };
+
+    openRequest.onerror = () => {
+      reject(new AppStateStorageError(`Failed to open local data storage${openRequest.error ? `: ${openRequest.error.message}` : ''}.`));
+    };
+
+    openRequest.onsuccess = () => {
+      const database = openRequest.result;
+      database.onversionchange = () => {
+        database.close();
+      };
+      resolve(database);
+    };
+  });
+};
+
+export const initializeAppStateStorage = async (): Promise<void> => {
+  const database = await openAppStateDatabase();
+
+  try {
+    const transaction = database.transaction([META_STORE], 'readwrite');
+    transaction.objectStore(META_STORE).put(APP_STATE_DB_VERSION, SCHEMA_VERSION_KEY);
+    await transactionDone(transaction);
+  } finally {
+    database.close();
+  }
+};
+
+export const loadAppStateFromIndexedDb = async (): Promise<AppState | null> => {
+  const database = await openAppStateDatabase();
+
+  try {
+    const transaction = database.transaction([APP_STATE_STORE], 'readonly');
+    const rawValue = await requestToPromise(transaction.objectStore(APP_STATE_STORE).get(APP_STATE_RECORD_KEY));
+    await transactionDone(transaction);
+
+    if (rawValue === undefined) {
+      return null;
+    }
+
+    return assertValid('appState', rawValue);
+  } finally {
+    database.close();
+  }
+};
+
+export const saveAppStateToIndexedDb = async (appState: unknown): Promise<void> => {
+  const database = await openAppStateDatabase();
+
+  try {
+    const validState = assertValid('appState', appState);
+    const transaction = database.transaction([APP_STATE_STORE, META_STORE], 'readwrite');
+
+    transaction.objectStore(APP_STATE_STORE).put(validState, APP_STATE_RECORD_KEY);
+    transaction.objectStore(META_STORE).put(validState.schemaVersion, SCHEMA_VERSION_KEY);
+
+    await transactionDone(transaction);
+  } finally {
+    database.close();
+  }
 };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -94,3 +94,44 @@ body {
     padding: 2rem 1rem;
   }
 }
+
+.storage-error-screen {
+  min-height: 100vh;
+  display: grid;
+  place-content: center;
+  gap: 0.75rem;
+  padding: 2rem 1.5rem;
+  text-align: center;
+}
+
+.storage-error-screen h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.storage-error-screen p {
+  margin: 0;
+  color: #4b5563;
+}
+
+.storage-error-actions {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.storage-error-actions button {
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #111827;
+  padding: 0.6rem 0.9rem;
+  font: inherit;
+  cursor: pointer;
+}
+
+.storage-error-actions button:hover {
+  background: #f9fafb;
+}


### PR DESCRIPTION
### Motivation

- Provide a robust local app-state persistence backend using IndexedDB to replace/augment simple storage and support schema migrations.
- Surface clear UI during storage initialization or when storage is unavailable or corrupted, and allow users to retry or reset local data.

### Description

- Introduced an IndexedDB-backed storage implementation in `frontend/src/data/index.ts` including `openAppStateDatabase`, `initializeAppStateStorage`, `loadAppStateFromIndexedDb`, `saveAppStateToIndexedDb`, migration from v1 to v2, and an `AppStateStorageError` type. 
- Added helper abstractions for IDB request/transaction promises and a `resetLocalData` helper in `frontend/src/App.tsx` that deletes the DB named `survival-garden` and triggers reinitialization. 
- Updated `frontend/src/App.tsx` to initialize storage on startup, show a startup screen while initializing, display a storage error screen when initialization fails, and expose `Retry` and `Reset local data` actions that call `initializeAppStateStorage` and `resetLocalData` respectively. 
- Added UI styles for the storage/error screens and controls in `frontend/src/index.css` under `.storage-error-screen` and `.storage-error-actions`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ebe04ff3483268c165c59af2a8f98)