### PR TITLE
Add batch contracts and in-memory batch repo filtering

### DIFF
--- a/fixtures/golden/trier-v1.json
+++ b/fixtures/golden/trier-v1.json
@@ -1,11 +1,12 @@
 {
+  "batches": [],
   "beds": [
     {
       "bedId": "bed_001",
       "createdAt": "2026-01-05T00:00:00Z",
       "gardenId": "garden_trier_001",
       "name": "Bed 1",
-      "notes": "Approx area 18 m² (documented in notes; no dedicated area field in current schema).",
+      "notes": "Approx area 18 m\u00b2 (documented in notes; no dedicated area field in current schema).",
       "updatedAt": "2026-01-05T00:00:00Z"
     },
     {
@@ -13,7 +14,7 @@
       "createdAt": "2026-01-05T00:00:00Z",
       "gardenId": "garden_trier_001",
       "name": "Bed 2",
-      "notes": "Approx area 18 m² (documented in notes; no dedicated area field in current schema).",
+      "notes": "Approx area 18 m\u00b2 (documented in notes; no dedicated area field in current schema).",
       "updatedAt": "2026-01-05T00:00:00Z"
     },
     {
@@ -21,7 +22,7 @@
       "createdAt": "2026-01-05T00:00:00Z",
       "gardenId": "garden_trier_001",
       "name": "Bed 3",
-      "notes": "Approx area 17 m² (documented in notes; no dedicated area field in current schema).",
+      "notes": "Approx area 17 m\u00b2 (documented in notes; no dedicated area field in current schema).",
       "updatedAt": "2026-01-05T00:00:00Z"
     },
     {
@@ -29,7 +30,7 @@
       "createdAt": "2026-01-05T00:00:00Z",
       "gardenId": "garden_trier_001",
       "name": "Bed 4",
-      "notes": "Approx area 17 m² (documented in notes; no dedicated area field in current schema).",
+      "notes": "Approx area 17 m\u00b2 (documented in notes; no dedicated area field in current schema).",
       "updatedAt": "2026-01-05T00:00:00Z"
     },
     {
@@ -37,7 +38,7 @@
       "createdAt": "2026-01-05T00:00:00Z",
       "gardenId": "garden_trier_001",
       "name": "Bed 5",
-      "notes": "Approx area 18 m² (documented in notes; no dedicated area field in current schema).",
+      "notes": "Approx area 18 m\u00b2 (documented in notes; no dedicated area field in current schema).",
       "updatedAt": "2026-01-05T00:00:00Z"
     },
     {
@@ -45,7 +46,7 @@
       "createdAt": "2026-01-05T00:00:00Z",
       "gardenId": "garden_trier_001",
       "name": "Bed 6",
-      "notes": "Approx area 18 m² (documented in notes; no dedicated area field in current schema).",
+      "notes": "Approx area 18 m\u00b2 (documented in notes; no dedicated area field in current schema).",
       "updatedAt": "2026-01-05T00:00:00Z"
     },
     {
@@ -53,7 +54,7 @@
       "createdAt": "2026-01-05T00:00:00Z",
       "gardenId": "garden_trier_001",
       "name": "Bed 7",
-      "notes": "Approx area 17 m² (documented in notes; no dedicated area field in current schema).",
+      "notes": "Approx area 17 m\u00b2 (documented in notes; no dedicated area field in current schema).",
       "updatedAt": "2026-01-05T00:00:00Z"
     },
     {
@@ -61,7 +62,7 @@
       "createdAt": "2026-01-05T00:00:00Z",
       "gardenId": "garden_trier_001",
       "name": "Bed 8",
-      "notes": "Approx area 17 m² (documented in notes; no dedicated area field in current schema).",
+      "notes": "Approx area 17 m\u00b2 (documented in notes; no dedicated area field in current schema).",
       "updatedAt": "2026-01-05T00:00:00Z"
     }
   ],

--- a/frontend/src/contracts/app-state.schema.json
+++ b/frontend/src/contracts/app-state.schema.json
@@ -9,6 +9,7 @@
     "beds",
     "crops",
     "cropPlans",
+    "batches",
     "tasks",
     "seedInventoryItems",
     "settings"
@@ -34,6 +35,12 @@
       "type": "array",
       "items": {
         "$ref": "https://survivalgarden/contracts/crop-plan.schema.json"
+      }
+    },
+    "batches": {
+      "type": "array",
+      "items": {
+        "$ref": "https://survivalgarden/contracts/batch.schema.json"
       }
     },
     "tasks": {

--- a/frontend/src/contracts/appstate.schema.test.ts
+++ b/frontend/src/contracts/appstate.schema.test.ts
@@ -10,6 +10,7 @@ declare global {
 import { describe, expect, it } from 'vitest';
 import Ajv2020 from 'ajv/dist/2020';
 import appStateSchema from './app-state.schema.json';
+import batchSchema from './batch.schema.json';
 import bedSchema from './bed.schema.json';
 import cropPlanSchema from './crop-plan.schema.json';
 import cropSchema from './crop.schema.json';
@@ -65,6 +66,7 @@ const formatAjvErrors = (errors: unknown): string => {
 describe('AppState schema', () => {
   const buildValidator = () => {
     const ajv = new Ajv2020({ strict: true });
+    ajv.addSchema(batchSchema);
     ajv.addSchema(bedSchema);
     ajv.addSchema(cropSchema);
     ajv.addSchema(cropPlanSchema);
@@ -140,6 +142,16 @@ describe('AppState schema', () => {
           },
         },
       ],
+      batches: [
+        {
+          batchId: 'batch_001',
+          cropId: 'crop_tomato',
+          startedAt: '2026-03-01T00:00:00Z',
+          stage: 'sowing',
+          stageEvents: [{ stage: 'sowing', occurredAt: '2026-03-01T00:00:00Z' }],
+          assignments: [{ bedId: 'bed_001', assignedAt: '2026-03-01T00:00:00Z' }],
+        },
+      ],
       tasks: [
         {
           id: 'task_001',
@@ -187,6 +199,7 @@ describe('AppState schema', () => {
       beds: [],
       crops: [],
       cropPlans: [],
+      batches: [],
       tasks: [],
       seedInventoryItems: [],
       settings: {

--- a/frontend/src/contracts/batch.schema.json
+++ b/frontend/src/contracts/batch.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://survivalgarden/contracts/batch.schema.json",
+  "title": "Batch",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "batchId",
+    "cropId",
+    "startedAt",
+    "stage",
+    "stageEvents",
+    "assignments"
+  ],
+  "properties": {
+    "batchId": {
+      "$ref": "#/$defs/id"
+    },
+    "cropId": {
+      "$ref": "#/$defs/id"
+    },
+    "startedAt": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?Z$"
+    },
+    "stage": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80
+    },
+    "stageEvents": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["stage", "occurredAt"],
+        "properties": {
+          "stage": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80
+          },
+          "occurredAt": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?Z$"
+          }
+        }
+      }
+    },
+    "assignments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["bedId", "assignedAt"],
+        "properties": {
+          "bedId": {
+            "$ref": "#/$defs/id"
+          },
+          "assignedAt": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?Z$"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    }
+  }
+}

--- a/frontend/src/contracts/index.ts
+++ b/frontend/src/contracts/index.ts
@@ -1,4 +1,5 @@
 import appStateSchema from './app-state.schema.json';
+import batchSchema from './batch.schema.json';
 import bedSchema from './bed.schema.json';
 import cropPlanSchema from './crop-plan.schema.json';
 import cropSchema from './crop.schema.json';
@@ -8,6 +9,7 @@ import taskSchema from './task.schema.json';
 
 export {
   appStateSchema,
+  batchSchema,
   bedSchema,
   cropPlanSchema,
   cropSchema,

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -19,19 +19,28 @@ export {
   removeCropPlanFromAppState,
   upsertCropPlanInAppState,
 } from './repos/cropPlanRepository';
+export {
+  getBatchFromAppState,
+  listBatchesFromAppState,
+  removeBatchFromAppState,
+  upsertBatchInAppState,
+} from './repos/batchRepository';
 
 const APP_STATE_DB_NAME = 'survival-garden';
-const APP_STATE_DB_VERSION = 4;
+const APP_STATE_DB_VERSION = 5;
 const APP_STATE_STORE = 'appState';
 const APP_STATE_RECORD_KEY = 'current';
 const META_STORE = 'meta';
 const BED_INDEX_STORE = 'bedsById';
 const CROP_INDEX_STORE = 'cropsById';
 const CROP_PLAN_INDEX_STORE = 'cropPlansById';
+const BATCH_INDEX_STORE = 'batchesById';
 const SCHEMA_VERSION_KEY = 'schemaVersion';
 
 export type {
   AppStateRepository,
+  BatchListFilter,
+  BatchRepository,
   BedRepository,
   CropPlanRepository,
   CropRepository,
@@ -129,6 +138,12 @@ const migrateV3ToV4 = (database: IDBDatabase): void => {
   }
 };
 
+const migrateV4ToV5 = (database: IDBDatabase): void => {
+  if (!database.objectStoreNames.contains(BATCH_INDEX_STORE)) {
+    database.createObjectStore(BATCH_INDEX_STORE, { keyPath: 'batchId' });
+  }
+};
+
 const openAppStateDatabase = async (): Promise<IDBDatabase> => {
   if (typeof indexedDB === 'undefined') {
     throw new AppStateStorageError('IndexedDB is not available in this environment.');
@@ -159,6 +174,10 @@ const openAppStateDatabase = async (): Promise<IDBDatabase> => {
 
       if (event.oldVersion < 4) {
         migrateV3ToV4(database);
+      }
+
+      if (event.oldVersion < 5) {
+        migrateV4ToV5(database);
       }
     };
 
@@ -216,7 +235,7 @@ export const saveAppStateToIndexedDb = async (appState: unknown): Promise<void> 
   try {
     const validState = assertValid('appState', appState);
     const transaction = database.transaction(
-      [APP_STATE_STORE, META_STORE, BED_INDEX_STORE, CROP_INDEX_STORE, CROP_PLAN_INDEX_STORE],
+      [APP_STATE_STORE, META_STORE, BED_INDEX_STORE, CROP_INDEX_STORE, CROP_PLAN_INDEX_STORE, BATCH_INDEX_STORE],
       'readwrite',
     );
 
@@ -254,6 +273,17 @@ export const saveAppStateToIndexedDb = async (appState: unknown): Promise<void> 
 
     for (const cropPlan of validState.cropPlans) {
       cropPlanStore.put(assertValid('cropPlan', cropPlan ?? {}));
+    }
+
+    const batchStore = transaction.objectStore(BATCH_INDEX_STORE);
+    const existingBatchKeys = await requestToPromise(batchStore.getAllKeys());
+
+    for (const key of existingBatchKeys) {
+      batchStore.delete(key);
+    }
+
+    for (const batch of validState.batches) {
+      batchStore.put(assertValid('batch', batch ?? {}));
     }
 
     await transactionDone(transaction);

--- a/frontend/src/data/repos/batchRepository.ts
+++ b/frontend/src/data/repos/batchRepository.ts
@@ -1,0 +1,88 @@
+import type { AppState, Batch } from '../../contracts';
+import { assertValid } from '../validation';
+import type { BatchListFilter, ListQuery } from './interfaces';
+
+const normalizeBatchCandidate = (value: unknown): unknown => value ?? {};
+
+const getDerivedBedId = (batch: Batch): string | null => {
+  if (batch.assignments.length === 0) {
+    return null;
+  }
+
+  const latestAssignment = batch.assignments.reduce((latest, assignment) =>
+    assignment.assignedAt > latest.assignedAt ? assignment : latest,
+  );
+
+  return latestAssignment.bedId;
+};
+
+export const getBatchFromAppState = (
+  appState: unknown,
+  batchId: Batch['batchId'],
+): Batch | null => {
+  const state = assertValid('appState', appState);
+  const candidate = state.batches.find((batch) => batch.batchId === batchId);
+
+  if (!candidate) {
+    return null;
+  }
+
+  return assertValid('batch', normalizeBatchCandidate(candidate));
+};
+
+export const listBatchesFromAppState = (
+  appState: unknown,
+  query: ListQuery<BatchListFilter> = {},
+): Batch[] => {
+  const state = assertValid('appState', appState);
+  const { filter } = query;
+
+  return state.batches
+    .filter((batch) => {
+      if (!filter) {
+        return true;
+      }
+
+      if (filter.stage && batch.stage !== filter.stage) {
+        return false;
+      }
+
+      if (filter.cropId && batch.cropId !== filter.cropId) {
+        return false;
+      }
+
+      if (filter.bedId && getDerivedBedId(batch) !== filter.bedId) {
+        return false;
+      }
+
+      if (filter.startedAtFrom && batch.startedAt < filter.startedAtFrom) {
+        return false;
+      }
+
+      if (filter.startedAtTo && batch.startedAt > filter.startedAtTo) {
+        return false;
+      }
+
+      return true;
+    })
+    .map((batch) => assertValid('batch', normalizeBatchCandidate(batch)));
+};
+
+export const upsertBatchInAppState = (appState: unknown, batch: unknown): AppState => {
+  const state = assertValid('appState', appState);
+  const validBatch = assertValid('batch', normalizeBatchCandidate(batch));
+  const existingIndex = state.batches.findIndex((entry) => entry.batchId === validBatch.batchId);
+
+  const batches =
+    existingIndex >= 0
+      ? state.batches.map((entry, index) => (index === existingIndex ? validBatch : entry))
+      : [...state.batches, validBatch];
+
+  return assertValid('appState', { ...state, batches });
+};
+
+export const removeBatchFromAppState = (appState: unknown, batchId: Batch['batchId']): AppState => {
+  const state = assertValid('appState', appState);
+  const batches = state.batches.filter((batch) => batch.batchId !== batchId);
+  return assertValid('appState', { ...state, batches });
+};

--- a/frontend/src/data/repos/interfaces.ts
+++ b/frontend/src/data/repos/interfaces.ts
@@ -1,5 +1,6 @@
 import type {
   AppState,
+  Batch,
   Bed,
   Crop,
   CropPlan,
@@ -40,6 +41,17 @@ export type CropRepository = CrudRepository<Crop, Crop['cropId']> & ListableRepo
 
 export type CropPlanRepository = CrudRepository<CropPlan, CropPlan['planId']> &
   ListableRepository<CropPlan, Pick<CropPlan, 'cropId' | 'seasonYear'>>;
+
+export type BatchListFilter = {
+  stage: Batch['stage'];
+  cropId: Batch['cropId'];
+  bedId: string;
+  startedAtFrom: string;
+  startedAtTo: string;
+};
+
+export type BatchRepository = CrudRepository<Batch, Batch['batchId']> &
+  ListableRepository<Batch, BatchListFilter>;
 
 export type TaskRepository = CrudRepository<Task, Task['id']> &
   ListableRepository<Task, Pick<Task, 'date' | 'status'>>;

--- a/frontend/src/data/validation/index.test.ts
+++ b/frontend/src/data/validation/index.test.ts
@@ -16,6 +16,10 @@ import {
   listCropPlansFromAppState,
   upsertCropPlanInAppState,
   removeCropPlanFromAppState,
+  getBatchFromAppState,
+  listBatchesFromAppState,
+  upsertBatchInAppState,
+  removeBatchFromAppState,
 } from '..';
 
 const goldenFixtures = import.meta.glob('../../../../fixtures/golden/*.json', {
@@ -148,11 +152,21 @@ const validCropPlan = {
   notes: 'Main spring bed',
 };
 
+const validBatch = {
+  batchId: 'batch-1',
+  cropId: 'crop-1',
+  startedAt: '2024-03-01T00:00:00Z',
+  stage: 'sowing',
+  stageEvents: [{ stage: 'sowing', occurredAt: '2024-03-01T00:00:00Z' }],
+  assignments: [{ bedId: 'bed-1', assignedAt: '2024-03-01T00:00:00Z' }],
+};
+
 const validAppState = {
   schemaVersion: 1,
   beds: [validBed],
   crops: [validCrop],
   cropPlans: [validCropPlan],
+  batches: [validBatch],
   tasks: [],
   seedInventoryItems: [],
   settings: {
@@ -355,5 +369,52 @@ describe('crop plan repository boundary helpers', () => {
   it('supports MVP empty cropPlans arrays without throwing', () => {
     const appStateWithNoPlans = { ...validAppState, cropPlans: [] };
     expect(listCropPlansFromAppState(appStateWithNoPlans)).toEqual([]);
+  });
+});
+
+
+describe('batch repository boundary helpers', () => {
+  it('rejects invalid stageEvents and assignments via schema validation', () => {
+    expect(() =>
+      upsertBatchInAppState(validAppState, {
+        ...validBatch,
+        stageEvents: [{ stage: '', occurredAt: '2024-03-01T00:00:00Z' }],
+      }),
+    ).toThrowError(SchemaValidationError);
+
+    expect(() =>
+      upsertBatchInAppState(validAppState, {
+        ...validBatch,
+        assignments: [{ bedId: '', assignedAt: '2024-03-01T00:00:00Z' }],
+      }),
+    ).toThrowError(SchemaValidationError);
+  });
+
+  it('supports batch read/update/remove and list filters', () => {
+    const secondBatch = {
+      batchId: 'batch-2',
+      cropId: 'crop-1',
+      startedAt: '2024-04-15T00:00:00Z',
+      stage: 'transplant',
+      stageEvents: [{ stage: 'transplant', occurredAt: '2024-04-15T00:00:00Z' }],
+      assignments: [{ bedId: 'bed-2', assignedAt: '2024-04-15T00:00:00Z' }],
+    };
+
+    const withSecondBatch = upsertBatchInAppState(validAppState, secondBatch);
+
+    expect(getBatchFromAppState(withSecondBatch, validBatch.batchId)).toEqual(validBatch);
+    expect(getBatchFromAppState(withSecondBatch, 'missing-batch')).toBeNull();
+
+    expect(listBatchesFromAppState(withSecondBatch, { filter: { stage: 'sowing' } })).toEqual([validBatch]);
+    expect(listBatchesFromAppState(withSecondBatch, { filter: { cropId: 'crop-1' } })).toHaveLength(2);
+    expect(listBatchesFromAppState(withSecondBatch, { filter: { bedId: 'bed-2' } })).toEqual([secondBatch]);
+    expect(
+      listBatchesFromAppState(withSecondBatch, {
+        filter: { startedAtFrom: '2024-04-01T00:00:00Z', startedAtTo: '2024-04-30T23:59:59Z' },
+      }),
+    ).toEqual([secondBatch]);
+
+    const removed = removeBatchFromAppState(withSecondBatch, secondBatch.batchId);
+    expect(getBatchFromAppState(removed, secondBatch.batchId)).toBeNull();
   });
 });

--- a/frontend/src/data/validation/index.ts
+++ b/frontend/src/data/validation/index.ts
@@ -2,6 +2,7 @@ import Ajv2020 from 'ajv/dist/2020';
 import type { ErrorObject, ValidateFunction } from 'ajv';
 import {
   appStateSchema,
+  batchSchema,
   bedSchema,
   cropPlanSchema,
   cropSchema,
@@ -11,6 +12,7 @@ import {
 } from '../../contracts';
 import type {
   AppState,
+  Batch,
   Bed,
   Crop,
   CropPlan,
@@ -21,6 +23,7 @@ import type {
 
 export type SchemaName =
   | 'appState'
+  | 'batch'
   | 'bed'
   | 'crop'
   | 'cropPlan'
@@ -30,6 +33,7 @@ export type SchemaName =
 
 export type SchemaTypeMap = {
   appState: AppState;
+  batch: Batch;
   bed: Bed;
   crop: Crop;
   cropPlan: CropPlan;
@@ -60,6 +64,7 @@ export class SchemaValidationError extends Error {
 const ajv = new Ajv2020({ allErrors: true, strict: true });
 
 ajv.addSchema(appStateSchema);
+ajv.addSchema(batchSchema);
 ajv.addSchema(bedSchema);
 ajv.addSchema(cropSchema);
 ajv.addSchema(cropPlanSchema);
@@ -69,6 +74,7 @@ ajv.addSchema(settingsSchema);
 
 const validators: { [K in SchemaName]: ValidateFunction<SchemaTypeMap[K]> } = {
   appState: ajv.compile<SchemaTypeMap['appState']>(appStateSchema),
+  batch: ajv.compile<SchemaTypeMap['batch']>(batchSchema),
   bed: ajv.compile<SchemaTypeMap['bed']>(bedSchema),
   crop: ajv.compile<SchemaTypeMap['crop']>(cropSchema),
   cropPlan: ajv.compile<SchemaTypeMap['cropPlan']>(cropPlanSchema),

--- a/frontend/src/generated/contracts.ts
+++ b/frontend/src/generated/contracts.ts
@@ -3,6 +3,26 @@
  * Regenerate with `pnpm --filter frontend gen:types`.
  */
 
+
+export interface BatchStageEvent {
+  stage: string;
+  occurredAt: string;
+}
+
+export interface BatchAssignment {
+  bedId: string;
+  assignedAt: string;
+}
+
+export interface Batch {
+  batchId: string;
+  cropId: string;
+  startedAt: string;
+  stage: string;
+  stageEvents: BatchStageEvent[];
+  assignments: BatchAssignment[];
+}
+
 export interface Bed {
   bedId: string;
   gardenId: string;
@@ -121,6 +141,7 @@ export interface AppState {
   beds: Bed[];
   crops: Crop[];
   cropPlans: CropPlan[];
+  batches: Batch[];
   tasks: Task[];
   seedInventoryItems: SeedInventoryItem[];
   settings: Settings;


### PR DESCRIPTION
### Motivation

- Introduce a first-class `Batch` contract so batches can be part of the canonical `AppState` and validated alongside other domain entities. 
- Provide minimal in-memory repository helpers and query filtering so UI pages (e.g. `BatchesPage`) can operate on batches without changing domain logic or persistence semantics. 
- Keep changes small and low-risk (Option A): filtering done in-memory, persistence migration added for parity with existing index stores.

### Description

- Added a new JSON schema `frontend/src/contracts/batch.schema.json` and wired `batches` into the `AppState` schema at `frontend/src/contracts/app-state.schema.json` and test harness `frontend/src/contracts/appstate.schema.test.ts`. 
- Registered the `batch` schema with AJV and extended validation types in `frontend/src/data/validation/index.ts`. 
- Added TypeScript shape for `Batch` to `frontend/src/generated/contracts.ts` (manually updated to reflect new schema since type generation could not run in this environment). 
- Implemented in-memory batch repository helpers `getBatchFromAppState`, `listBatchesFromAppState`, `upsertBatchInAppState`, `removeBatchFromAppState` in `frontend/src/data/repos/batchRepository.ts` and exposed them from `frontend/src/data/index.ts`. 
- Extended repo interfaces in `frontend/src/data/repos/interfaces.ts` with `BatchRepository` and `BatchListFilter` (supporting `stage`, `cropId`, derived `bedId` from latest assignment, and `startedAt` range). 
- Bumped internal IndexedDB schema version to `5` and added a `batchesById` index store with save/load parity in `frontend/src/data/index.ts`. 
- Added focused unit tests to `frontend/src/data/validation/index.test.ts` covering schema rejection for invalid `stageEvents`/`assignments` and batch CRUD + filter behavior, and updated `fixtures/golden/trier-v1.json` to include `batches`.

### Testing

- Attempted to regenerate contract types with `pnpm --filter frontend gen:types`, which failed due to missing local dependencies (`json-schema-to-typescript` / `node_modules`) in this environment, so the generated types file was updated manually; type generation was not executed successfully. (failed)
- No unit test runner was executed in this environment; new tests were added under `frontend/src/data/validation/index.test.ts` but were not run here. (not executed)
- Basic repository consistency checks (code edits, imports, and local builds) were validated by static edits in the workspace but no automated test suite was run to completion here. (not executed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a182b032c883268a7c3f871ae7636d)