### PR TITLE
Add seed inventory CRUD and settings helpers at app-state boundary

### DIFF
--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -25,6 +25,18 @@ export {
   removeBatchFromAppState,
   upsertBatchInAppState,
 } from './repos/batchRepository';
+
+export {
+  getSeedInventoryItemFromAppState,
+  listSeedInventoryItemsFromAppState,
+  removeSeedInventoryItemFromAppState,
+  upsertSeedInventoryItemInAppState,
+} from './repos/seedInventoryRepository';
+export {
+  getSettingsFromAppState,
+  getSettingsOrDefault,
+  saveSettingsInAppState,
+} from './repos/settingsRepository';
 export {
   getTaskFromAppState,
   listTasksFromAppState,

--- a/frontend/src/data/repos/seedInventoryRepository.ts
+++ b/frontend/src/data/repos/seedInventoryRepository.ts
@@ -1,0 +1,83 @@
+import type { AppState, SeedInventoryItem } from '../../contracts';
+import { assertValid } from '../validation';
+import type { ListQuery } from './interfaces';
+
+const normalizeSeedInventoryItemCandidate = (value: unknown): unknown => value ?? {};
+
+export const getSeedInventoryItemFromAppState = (
+  appState: unknown,
+  seedInventoryItemId: SeedInventoryItem['seedInventoryItemId'],
+): SeedInventoryItem | null => {
+  const state = assertValid('appState', appState);
+  const candidate = state.seedInventoryItems.find(
+    (seedInventoryItem) => seedInventoryItem.seedInventoryItemId === seedInventoryItemId,
+  );
+
+  if (!candidate) {
+    return null;
+  }
+
+  return assertValid('seedInventoryItem', normalizeSeedInventoryItemCandidate(candidate));
+};
+
+export const listSeedInventoryItemsFromAppState = (
+  appState: unknown,
+  query: ListQuery<Pick<SeedInventoryItem, 'cropId' | 'status'>> = {},
+): SeedInventoryItem[] => {
+  const state = assertValid('appState', appState);
+  const { filter } = query;
+
+  return state.seedInventoryItems
+    .filter((seedInventoryItem) => {
+      if (!filter) {
+        return true;
+      }
+
+      if (filter.cropId && seedInventoryItem.cropId !== filter.cropId) {
+        return false;
+      }
+
+      if (filter.status && seedInventoryItem.status !== filter.status) {
+        return false;
+      }
+
+      return true;
+    })
+    .map((seedInventoryItem) =>
+      assertValid('seedInventoryItem', normalizeSeedInventoryItemCandidate(seedInventoryItem)),
+    );
+};
+
+export const upsertSeedInventoryItemInAppState = (
+  appState: unknown,
+  seedInventoryItem: unknown,
+): AppState => {
+  const state = assertValid('appState', appState);
+  const validSeedInventoryItem = assertValid(
+    'seedInventoryItem',
+    normalizeSeedInventoryItemCandidate(seedInventoryItem),
+  );
+  const existingIndex = state.seedInventoryItems.findIndex(
+    (entry) => entry.seedInventoryItemId === validSeedInventoryItem.seedInventoryItemId,
+  );
+
+  const seedInventoryItems =
+    existingIndex >= 0
+      ? state.seedInventoryItems.map((entry, index) =>
+          index === existingIndex ? validSeedInventoryItem : entry,
+        )
+      : [...state.seedInventoryItems, validSeedInventoryItem];
+
+  return assertValid('appState', { ...state, seedInventoryItems });
+};
+
+export const removeSeedInventoryItemFromAppState = (
+  appState: unknown,
+  seedInventoryItemId: SeedInventoryItem['seedInventoryItemId'],
+): AppState => {
+  const state = assertValid('appState', appState);
+  const seedInventoryItems = state.seedInventoryItems.filter(
+    (seedInventoryItem) => seedInventoryItem.seedInventoryItemId !== seedInventoryItemId,
+  );
+  return assertValid('appState', { ...state, seedInventoryItems });
+};

--- a/frontend/src/data/repos/settingsRepository.ts
+++ b/frontend/src/data/repos/settingsRepository.ts
@@ -1,0 +1,44 @@
+import type { AppState, Settings } from '../../contracts';
+import { assertValid } from '../validation';
+
+const normalizeSettingsCandidate = (value: unknown): unknown => value ?? {};
+
+const buildDefaultSettings = (): Settings => {
+  const now = new Date().toISOString();
+
+  return assertValid('settings', {
+    settingsId: 'settings-default',
+    locale: 'de-DE',
+    timezone: 'Europe/Berlin',
+    weekStartsOn: 'monday',
+    units: {
+      temperature: 'celsius',
+      yield: 'metric',
+    },
+    createdAt: now,
+    updatedAt: now,
+  });
+};
+
+export const getSettingsFromAppState = (appState: unknown): Settings => {
+  const state = assertValid('appState', appState);
+  return assertValid('settings', normalizeSettingsCandidate(state.settings));
+};
+
+export const saveSettingsInAppState = (appState: unknown, settings: unknown): AppState => {
+  const state = assertValid('appState', appState);
+  const validSettings = assertValid('settings', normalizeSettingsCandidate(settings));
+
+  return assertValid('appState', {
+    ...state,
+    settings: validSettings,
+  });
+};
+
+export const getSettingsOrDefault = (settings: unknown): Settings => {
+  try {
+    return assertValid('settings', normalizeSettingsCandidate(settings));
+  } catch {
+    return buildDefaultSettings();
+  }
+};

--- a/frontend/src/data/validation/index.test.ts
+++ b/frontend/src/data/validation/index.test.ts
@@ -25,6 +25,13 @@ import {
   upsertTaskInAppState,
   removeTaskFromAppState,
   upsertGeneratedTasksInAppState,
+  getSeedInventoryItemFromAppState,
+  listSeedInventoryItemsFromAppState,
+  upsertSeedInventoryItemInAppState,
+  removeSeedInventoryItemFromAppState,
+  getSettingsFromAppState,
+  saveSettingsInAppState,
+  getSettingsOrDefault,
 } from '..';
 
 const goldenFixtures = import.meta.glob('../../../../fixtures/golden/*.json', {
@@ -176,6 +183,17 @@ const validTask = {
   batchId: 'batch-1',
   checklist: [{ step: 'Water thoroughly' }],
   status: 'done',
+};
+
+const validSeedInventoryItem = {
+  seedInventoryItemId: 'seed-item-1',
+  cropId: 'crop-1',
+  variety: 'Nantes',
+  quantity: 120,
+  unit: 'seeds',
+  status: 'available',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-02T00:00:00Z',
 };
 
 const validAppState = {
@@ -531,5 +549,58 @@ describe('generated task upsert boundary helper', () => {
     ]);
 
     expect(merged.tasks).toEqual([secondGeneratedDuplicate]);
+  });
+});
+
+describe('seed inventory repository boundary helpers', () => {
+  it('supports seed inventory read/upsert/remove and list filters', () => {
+    const withSeedItem = upsertSeedInventoryItemInAppState(validAppState, validSeedInventoryItem);
+
+    expect(
+      getSeedInventoryItemFromAppState(withSeedItem, validSeedInventoryItem.seedInventoryItemId),
+    ).toEqual(validSeedInventoryItem);
+    expect(getSeedInventoryItemFromAppState(withSeedItem, 'missing-seed-item')).toBeNull();
+
+    expect(listSeedInventoryItemsFromAppState(withSeedItem, { filter: { cropId: 'crop-1' } })).toEqual([
+      validSeedInventoryItem,
+    ]);
+    expect(
+      listSeedInventoryItemsFromAppState(withSeedItem, { filter: { status: 'available' } }),
+    ).toEqual([validSeedInventoryItem]);
+
+    const removed = removeSeedInventoryItemFromAppState(
+      withSeedItem,
+      validSeedInventoryItem.seedInventoryItemId,
+    );
+
+    expect(
+      getSeedInventoryItemFromAppState(removed, validSeedInventoryItem.seedInventoryItemId),
+    ).toBeNull();
+  });
+});
+
+describe('settings repository boundary helpers', () => {
+  it('supports settings get/save paths', () => {
+    expect(getSettingsFromAppState(validAppState)).toEqual(validAppState.settings);
+
+    const saved = saveSettingsInAppState(validAppState, {
+      ...validAppState.settings,
+      locale: 'en-US',
+      updatedAt: '2024-02-01T00:00:00Z',
+    });
+
+    expect(saved.settings).toEqual({
+      ...validAppState.settings,
+      locale: 'en-US',
+      updatedAt: '2024-02-01T00:00:00Z',
+    });
+  });
+
+  it('returns schema-valid defaults when settings are absent or invalid', () => {
+    const fallbackForMissing = getSettingsOrDefault(undefined);
+    const fallbackForInvalid = getSettingsOrDefault({ locale: 'bad' });
+
+    expect(assertValid('settings', fallbackForMissing)).toEqual(fallbackForMissing);
+    expect(assertValid('settings', fallbackForInvalid)).toEqual(fallbackForInvalid);
   });
 });


### PR DESCRIPTION
### Motivation
- Provide minimal app-state boundary helpers for seed inventory CRUD and settings management so the app can persist/load these segments without schema violations.
- Keep the implementation consistent with existing repository-helper patterns and avoid touching IndexedDB migrations or domain logic.

### Description
- Add `frontend/src/data/repos/seedInventoryRepository.ts` implementing `getSeedInventoryItemFromAppState`, `listSeedInventoryItemsFromAppState`, `upsertSeedInventoryItemInAppState`, and `removeSeedInventoryItemFromAppState` with schema validation via `assertValid`.
- Add `frontend/src/data/repos/settingsRepository.ts` implementing `getSettingsFromAppState`, `saveSettingsInAppState`, and `getSettingsOrDefault` which returns a schema-valid default when input is absent or invalid.
- Re-export the new helpers from `frontend/src/data/index.ts` so callers can import them from the central module.
- Extend `frontend/src/data/validation/index.test.ts` with tests for seed inventory CRUD/filter behavior and for settings get/save/default behavior, while keeping persistence and domain behavior unchanged.

### Testing
- Added unit tests in `frontend/src/data/validation/index.test.ts` exercising seed inventory read/upsert/remove, list filters, and settings get/save/default fallback behavior.
- No automated test run was executed as part of this patch (per FAST PATCH MODE), so test execution results are not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a19e221808832689fcd1a3684f2d2d)