### PR TITLE
Implement batches list filtering with URL params and detail navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
-import { Navigate, NavLink, Route, Routes } from 'react-router-dom';
-import { initializeAppStateStorage, resetToGoldenDataset } from './data';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, Navigate, NavLink, Route, Routes, useParams, useSearchParams } from 'react-router-dom';
+import type { Batch } from './contracts';
+import { initializeAppStateStorage, listBatchesFromAppState, loadAppStateFromIndexedDb, resetToGoldenDataset } from './data';
 
 function BedsPage() {
   return <p>Beds</p>;
@@ -10,8 +11,203 @@ function CalendarPage() {
   return <p>Calendar</p>;
 }
 
+const getDerivedBedId = (batch: Batch): string | null => {
+  if (batch.assignments.length === 0) {
+    return null;
+  }
+
+  const latestAssignment = batch.assignments.reduce((latest, assignment) =>
+    assignment.assignedAt > latest.assignedAt ? assignment : latest,
+  );
+
+  return latestAssignment.bedId;
+};
+
 function BatchesPage() {
-  return <p>Batches</p>;
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [batches, setBatches] = useState<Batch[]>([]);
+  const [cropNames, setCropNames] = useState<Record<string, string>>({});
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      const appState = await loadAppStateFromIndexedDb();
+
+      if (!appState) {
+        setBatches([]);
+        setCropNames({});
+        setIsLoading(false);
+        return;
+      }
+
+      setBatches(listBatchesFromAppState(appState));
+      setCropNames(Object.fromEntries(appState.crops.map((crop) => [crop.cropId, crop.name])));
+      setIsLoading(false);
+    };
+
+    void load();
+  }, []);
+
+  const filters = {
+    crop: searchParams.get('crop') ?? '',
+    stage: searchParams.get('stage') ?? '',
+    bed: searchParams.get('bed') ?? '',
+    from: searchParams.get('from') ?? '',
+    to: searchParams.get('to') ?? '',
+  };
+
+  const cropOptions = useMemo(
+    () =>
+      Array.from(new Set(batches.map((batch) => batch.cropId)))
+        .sort((left, right) => (cropNames[left] ?? left).localeCompare(cropNames[right] ?? right))
+        .map((cropId) => ({ value: cropId, label: cropNames[cropId] ?? cropId })),
+    [batches, cropNames],
+  );
+
+  const stageOptions = useMemo(
+    () => Array.from(new Set(batches.map((batch) => batch.stage))).sort(),
+    [batches],
+  );
+
+  const bedOptions = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          batches
+            .map((batch) => getDerivedBedId(batch))
+            .filter((bedId): bedId is string => Boolean(bedId)),
+        ),
+      ).sort(),
+    [batches],
+  );
+
+  const filteredBatches = useMemo(
+    () =>
+      batches.filter((batch) => {
+        const derivedBedId = getDerivedBedId(batch);
+        const batchDate = batch.startedAt.slice(0, 10);
+
+        if (filters.crop && batch.cropId !== filters.crop) {
+          return false;
+        }
+
+        if (filters.stage && batch.stage !== filters.stage) {
+          return false;
+        }
+
+        if (filters.bed && derivedBedId !== filters.bed) {
+          return false;
+        }
+
+        if (filters.from && batchDate < filters.from) {
+          return false;
+        }
+
+        if (filters.to && batchDate > filters.to) {
+          return false;
+        }
+
+        return true;
+      }),
+    [batches, filters],
+  );
+
+  const updateFilter = (name: string, value: string) => {
+    const next = new URLSearchParams(searchParams);
+
+    if (value) {
+      next.set(name, value);
+    } else {
+      next.delete(name);
+    }
+
+    setSearchParams(next, { replace: true });
+  };
+
+  return (
+    <section className="batches-page">
+      <h2>Batches</h2>
+
+      <div className="batch-filters">
+        <label>
+          Crop
+          <select value={filters.crop} onChange={(event) => updateFilter('crop', event.target.value)}>
+            <option value="">All</option>
+            {cropOptions.map((crop) => (
+              <option key={crop.value} value={crop.value}>
+                {crop.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          Stage
+          <select value={filters.stage} onChange={(event) => updateFilter('stage', event.target.value)}>
+            <option value="">All</option>
+            {stageOptions.map((stage) => (
+              <option key={stage} value={stage}>
+                {stage}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          Bed
+          <select value={filters.bed} onChange={(event) => updateFilter('bed', event.target.value)}>
+            <option value="">All</option>
+            {bedOptions.map((bedId) => (
+              <option key={bedId} value={bedId}>
+                {bedId}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          From
+          <input type="date" value={filters.from} onChange={(event) => updateFilter('from', event.target.value)} />
+        </label>
+
+        <label>
+          To
+          <input type="date" value={filters.to} onChange={(event) => updateFilter('to', event.target.value)} />
+        </label>
+      </div>
+
+      {isLoading ? <p className="batch-empty-state">Loading batches…</p> : null}
+
+      {!isLoading ? (
+        <ul className="batch-list">
+          {filteredBatches.map((batch) => (
+            <li key={batch.batchId}>
+              <Link to={`/batches/${batch.batchId}`} className="batch-item-link">
+                <div>
+                  <p className="batch-item-title">{cropNames[batch.cropId] ?? batch.cropId}</p>
+                  <p className="batch-item-meta">
+                    Batch {batch.batchId} · Bed {getDerivedBedId(batch) ?? 'Unassigned'} · Started{' '}
+                    {batch.startedAt.slice(0, 10)}
+                  </p>
+                </div>
+                <span className="batch-stage-badge">{batch.stage}</span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {!isLoading && filteredBatches.length === 0 ? (
+        <p className="batch-empty-state">No batches match these filters.</p>
+      ) : null}
+    </section>
+  );
+}
+
+function BatchDetailPage() {
+  const { batchId } = useParams();
+
+  return <p>Batch detail: {batchId}</p>;
 }
 
 function NutritionPage() {
@@ -117,6 +313,7 @@ function App() {
           <Route path="/beds" element={<BedsPage />} />
           <Route path="/calendar" element={<CalendarPage />} />
           <Route path="/batches" element={<BatchesPage />} />
+          <Route path="/batches/:batchId" element={<BatchDetailPage />} />
           <Route path="/nutrition" element={<NutritionPage />} />
           <Route
             path="/data"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -36,8 +36,6 @@ body {
 
 .app-content {
   display: grid;
-  place-content: center;
-  text-align: center;
   padding: 1.5rem 1rem 5.5rem;
 }
 
@@ -45,6 +43,94 @@ body {
   margin: 0;
   font-size: 1.5rem;
   font-weight: 600;
+}
+
+.batches-page {
+  width: min(900px, 100%);
+  margin: 0 auto;
+  display: grid;
+  gap: 1rem;
+  text-align: left;
+}
+
+.batches-page h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.batch-filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.6rem;
+}
+
+.batch-filters label {
+  display: grid;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  color: #374151;
+}
+
+.batch-filters input,
+.batch-filters select {
+  border: 1px solid #d1d5db;
+  border-radius: 0.45rem;
+  padding: 0.45rem 0.55rem;
+  font: inherit;
+  background: #ffffff;
+}
+
+.batch-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.batch-item-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.75rem;
+  text-decoration: none;
+  color: inherit;
+  background: #ffffff;
+}
+
+.batch-item-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.batch-item-meta {
+  margin: 0.15rem 0 0;
+  font-size: 0.78rem;
+  color: #4b5563;
+  font-weight: 500;
+}
+
+.batch-stage-badge {
+  font-size: 0.75rem;
+  text-transform: capitalize;
+  background: #eef2ff;
+  color: #3730a3;
+  border-radius: 999px;
+  padding: 0.25rem 0.55rem;
+  border: 1px solid #c7d2fe;
+  font-weight: 700;
+}
+
+.batch-empty-state {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #6b7280;
 }
 
 .tab-nav {


### PR DESCRIPTION
### Motivation
- Replace the placeholder `/batches` page with a usable list so users can find batches by crop, stage, bed, and start date.
- Keep filtering behavior consistent with existing domain semantics, especially bed derivation via the latest assignment.
- Provide a clickable row and route target so users can navigate to a batch detail page even if the detail view is minimal for now.

### Description
- Replaced the placeholder `BatchesPage` in `frontend/src/App.tsx` with a full list UI that loads state via `loadAppStateFromIndexedDb` and uses `listBatchesFromAppState` to populate batches.
- Implemented client-side filters for `crop`, `stage`, `bed` (derived by latest assignment timestamp), and started-at date range, and synchronized filter state with URL query params (`crop`, `stage`, `bed`, `from`, `to`) using `useSearchParams`.
- Rendered each batch as a clickable link to `/batches/:batchId` and added a minimal `BatchDetailPage` route target so navigation works.
- Added presentational styling for the filters, list rows, badges, and empty/loading states in `frontend/src/index.css`.

### Testing
- Committed changes successfully with `git` (local commit created for the patch).
- Attempted an automated browser screenshot with Playwright targeting `http://127.0.0.1:5173/batches`, but it failed with `net::ERR_EMPTY_RESPONSE` because no dev server was running in this environment.
- No unit/integration test runs were executed in this environment; existing test files were not modified by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5542b96a883268d25b62f2851d7e2)