### PR TITLE
Add batch detail read-only view with timeline and assignment history

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -509,8 +509,171 @@ function BatchesPage() {
 
 function BatchDetailPage() {
   const { batchId } = useParams();
+  const [isLoading, setIsLoading] = useState(true);
+  const [batch, setBatch] = useState<Batch | null>(null);
+  const [cropName, setCropName] = useState<string | null>(null);
 
-  return <p>Batch detail: {batchId}</p>;
+  useEffect(() => {
+    const load = async () => {
+      if (!batchId) {
+        setBatch(null);
+        setCropName(null);
+        setIsLoading(false);
+        return;
+      }
+
+      setIsLoading(true);
+      const appState = await loadAppStateFromIndexedDb();
+
+      if (!appState) {
+        setBatch(null);
+        setCropName(null);
+        setIsLoading(false);
+        return;
+      }
+
+      const nextBatch = appState.batches.find((candidate) => candidate.batchId === batchId) ?? null;
+      setBatch(nextBatch);
+
+      if (!nextBatch) {
+        setCropName(null);
+        setIsLoading(false);
+        return;
+      }
+
+      const crop = appState.crops.find((candidate) => candidate.cropId === nextBatch.cropId);
+      setCropName(crop?.name ?? null);
+      setIsLoading(false);
+    };
+
+    void load();
+  }, [batchId]);
+
+  const orderedStageEvents = useMemo(() => {
+    if (!batch) {
+      return [];
+    }
+
+    return batch.stageEvents
+      .map((event, index) => ({ event, index }))
+      .sort((left, right) => {
+        const timestampCompare = left.event.occurredAt.localeCompare(right.event.occurredAt);
+        if (timestampCompare !== 0) {
+          return timestampCompare;
+        }
+
+        return left.index - right.index;
+      })
+      .map(({ event }) => event);
+  }, [batch]);
+
+  const assignmentHistory = useMemo(() => {
+    if (!batch) {
+      return [];
+    }
+
+    return [...batch.assignments].sort((left, right) => left.assignedAt.localeCompare(right.assignedAt));
+  }, [batch]);
+
+  if (isLoading) {
+    return <p className="batch-detail-empty">Loading batch…</p>;
+  }
+
+  if (!batch) {
+    return (
+      <section className="batch-detail-page">
+        <h2>Batch not found</h2>
+        <p className="batch-detail-empty">No batch matches ID {batchId ?? 'unknown'}.</p>
+        <Link to="/batches" className="batch-detail-back-link">
+          Back to batches
+        </Link>
+      </section>
+    );
+  }
+
+  return (
+    <section className="batch-detail-page">
+      <Link to="/batches" className="batch-detail-back-link">
+        ← Back to batches
+      </Link>
+      <h2>{cropName ?? batch.cropId}</h2>
+
+      <div className="batch-detail-grid">
+        <article className="batch-detail-card">
+          <h3>Metadata</h3>
+          <dl>
+            <div>
+              <dt>Batch ID</dt>
+              <dd>{batch.batchId}</dd>
+            </div>
+            <div>
+              <dt>Crop ID</dt>
+              <dd>{batch.cropId}</dd>
+            </div>
+            <div>
+              <dt>Stage</dt>
+              <dd>{batch.stage}</dd>
+            </div>
+            <div>
+              <dt>Started</dt>
+              <dd>{new Date(batch.startedAt).toLocaleString()}</dd>
+            </div>
+          </dl>
+        </article>
+
+        <article className="batch-detail-card">
+          <h3>Counts</h3>
+          <dl>
+            <div>
+              <dt>Stage events</dt>
+              <dd>{batch.stageEvents.length}</dd>
+            </div>
+            <div>
+              <dt>Assignments</dt>
+              <dd>{batch.assignments.length}</dd>
+            </div>
+            <div>
+              <dt>Current bed</dt>
+              <dd>{getDerivedBedId(batch) ?? 'Unassigned'}</dd>
+            </div>
+          </dl>
+        </article>
+      </div>
+
+      <article className="batch-detail-card">
+        <h3>Stage timeline</h3>
+        {orderedStageEvents.length === 0 ? (
+          <p className="batch-detail-empty">No stage events yet.</p>
+        ) : (
+          <ol className="batch-detail-list">
+            {orderedStageEvents.map((event, index) => (
+              <li key={`${event.occurredAt}-${event.stage}-${index}`}>
+                <span className="batch-detail-pill">{event.stage}</span>
+                <span>{new Date(event.occurredAt).toLocaleString()}</span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </article>
+
+      <article className="batch-detail-card">
+        <h3>Bed assignments</h3>
+        <p className="batch-detail-current-bed">Current: {getDerivedBedId(batch) ?? 'Unassigned'}</p>
+        {assignmentHistory.length === 0 ? (
+          <p className="batch-detail-empty">No bed assignment history.</p>
+        ) : (
+          <ol className="batch-detail-list">
+            {assignmentHistory.map((assignment, index) => (
+              <li key={`${assignment.assignedAt}-${assignment.bedId}-${index}`}>
+                <span className="batch-detail-pill">{assignment.bedId}</span>
+                <span>{new Date(assignment.assignedAt).toLocaleString()}</span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </article>
+    </section>
+  );
 }
 
 function NutritionPage() {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -301,3 +301,98 @@ body {
   font-size: 0.78rem;
   color: #6b7280;
 }
+
+.batch-detail-page {
+  width: min(900px, 100%);
+  margin: 0 auto;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.batch-detail-page h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.batch-detail-back-link {
+  color: #2563eb;
+  font-size: 0.88rem;
+  text-decoration: none;
+}
+
+.batch-detail-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.batch-detail-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 0.85rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.batch-detail-card h3 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.batch-detail-card dl {
+  margin: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.batch-detail-card dl div {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.batch-detail-card dt {
+  color: #4b5563;
+  font-size: 0.8rem;
+}
+
+.batch-detail-card dd {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #111827;
+  text-align: right;
+}
+
+.batch-detail-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.batch-detail-list li {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.82rem;
+  color: #374151;
+}
+
+.batch-detail-pill {
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  padding: 0.1rem 0.45rem;
+  font-size: 0.75rem;
+  color: #111827;
+  background: #f9fafb;
+}
+
+.batch-detail-current-bed,
+.batch-detail-empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #6b7280;
+  font-weight: 500;
+}


### PR DESCRIPTION
### Motivation
- Replace the placeholder batch detail route with a usable read-only view that supports deep links to `/batches/:batchId` and does not change domain behavior. 
- Present core batch information (metadata and counts), a deterministic stage-event timeline, and a bed-assignment summary/history derived only from existing batch data. 
- Ensure timeline ordering is stable when events share the same timestamp by tie-breaking with the original insertion index. 

### Description
- Implemented a full `BatchDetailPage` that resolves `batchId` from route params, loads state from IndexedDB using `loadAppStateFromIndexedDb`, and handles loading and not-found states gracefully. 
- Deterministic timeline: `stageEvents` are mapped with their insertion index and sorted by `occurredAt` then by index to preserve stable ordering. 
- Assignment history: `assignments` are displayed sorted by `assignedAt`, and the current bed is derived with the existing `getDerivedBedId` helper. 
- Presentation-only styling: added minimal CSS classes and rules for the detail page, cards, lists, pills, and back-link in `frontend/src/index.css` to match existing UI patterns. 

### Testing
- Attempted an automated Playwright screenshot of the batches page for visual verification, but navigation to the dev server failed with `ERR_EMPTY_RESPONSE` because the local app server was not running (test failed). 
- No unit or integration test suites were executed in this environment; changes are presentation-only and rely on existing domain contracts and IndexedDB helpers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a566e61b348326be949169695cd6e8)