### PR TITLE
Add StageAssessmentService domain interface seam

### DIFF
--- a/frontend/src/domain/services/StageAssessmentService.ts
+++ b/frontend/src/domain/services/StageAssessmentService.ts
@@ -1,0 +1,35 @@
+export interface StageAssessmentPhotoMeta {
+  readonly capturedAt?: string;
+  readonly source?: string;
+  readonly notes?: string;
+  readonly tags?: readonly string[];
+}
+
+export interface StageAssessmentContext {
+  readonly batchId: string;
+  readonly currentStage: string;
+  readonly cropId?: string;
+  readonly bedId?: string;
+}
+
+export interface StageAssessmentSuggestion {
+  readonly stage: string;
+  readonly confidence?: number;
+  readonly rationale?: string;
+}
+
+/**
+ * Extension seam for future stage suggestion integrations.
+ *
+ * TODO: Wire an adapter implementation in the app layer when external stage
+ * assessment is introduced.
+ *
+ * This contract is intentionally unused by default and does not alter existing
+ * domain transitions, persistence, or batch schema.
+ */
+export interface StageAssessmentService {
+  assessStage(
+    photoMeta: StageAssessmentPhotoMeta,
+    context: StageAssessmentContext,
+  ): Promise<StageAssessmentSuggestion>;
+}


### PR DESCRIPTION
### Motivation
- Provide a small extension seam for future ML-driven stage suggestions without changing domain behavior, persistence, or transitions; the interface is unused by default.

### Description
- Add `frontend/src/domain/services/StageAssessmentService.ts` exporting `StageAssessmentPhotoMeta`, `StageAssessmentContext`, `StageAssessmentSuggestion`, and the `StageAssessmentService` interface with an `assessStage` signature.
- Include doc comments and `TODO` guidance describing intended adapter wiring and unused-by-default status, with no runtime implementation.

### Testing
- No automated tests were added or run; this is a type-only addition and does not affect runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a58ab8fbac8326a3bf2fa0c6fc4c25)