### PR TITLE
Add canonical getActiveBedAssignment helper and use it across UI and repo

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import {
   saveAppStateToIndexedDb,
   savePhotoBlobToIndexedDb,
   upsertBatchInAppState,
+  getActiveBedAssignment,
 } from './data';
 import { applyStageEvent, canTransition } from './domain';
 
@@ -33,17 +34,7 @@ function CalendarPage() {
   return <p>Calendar</p>;
 }
 
-const getDerivedBedId = (batch: Batch): string | null => {
-  if (batch.assignments.length === 0) {
-    return null;
-  }
-
-  const latestAssignment = batch.assignments.reduce((latest, assignment) =>
-    assignment.assignedAt > latest.assignedAt ? assignment : latest,
-  );
-
-  return latestAssignment.bedId;
-};
+const getDerivedBedId = (batch: Batch): string | null => getActiveBedAssignment(batch, new Date().toISOString())?.bedId ?? null;
 
 const getLocalDateTimeDefault = () => {
   const date = new Date();

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -21,6 +21,7 @@ export {
   upsertCropPlanInAppState,
 } from './repos/cropPlanRepository';
 export {
+  getActiveBedAssignment,
   getBatchFromAppState,
   listBatchesFromAppState,
   removeBatchFromAppState,

--- a/frontend/src/data/repos/batchRepository.test.ts
+++ b/frontend/src/data/repos/batchRepository.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import type { Batch } from '../../contracts';
+import { getActiveBedAssignment } from './batchRepository';
+
+const createBatch = (assignments: Array<{ bedId: string; assignedAt: string; fromDate?: string; toDate?: string | null }>): Batch =>
+  ({
+    batchId: 'batch-1',
+    cropId: 'crop-1',
+    startedAt: '2026-01-01T00:00:00Z',
+    stage: 'sowing',
+    stageEvents: [{ stage: 'sowing', occurredAt: '2026-01-01T00:00:00Z' }],
+    assignments: assignments as Batch['assignments'],
+  });
+
+describe('getActiveBedAssignment', () => {
+  it('returns assignment when onDate equals fromDate', () => {
+    const batch = createBatch([{ bedId: 'bed-1', assignedAt: '2026-02-01T00:00:00Z', fromDate: '2026-02-01T00:00:00Z' }]);
+
+    expect(getActiveBedAssignment(batch, '2026-02-01T00:00:00Z')?.bedId).toBe('bed-1');
+  });
+
+  it('treats toDate as inclusive', () => {
+    const batch = createBatch([
+      {
+        bedId: 'bed-2',
+        assignedAt: '2026-02-01T00:00:00Z',
+        fromDate: '2026-02-01T00:00:00Z',
+        toDate: '2026-02-10T00:00:00Z',
+      },
+    ]);
+
+    expect(getActiveBedAssignment(batch, '2026-02-10T00:00:00Z')?.bedId).toBe('bed-2');
+  });
+
+  it('returns null before start date', () => {
+    const batch = createBatch([{ bedId: 'bed-3', assignedAt: '2026-03-01T00:00:00Z', fromDate: '2026-03-01T00:00:00Z' }]);
+
+    expect(getActiveBedAssignment(batch, '2026-02-28T23:59:59Z')).toBeNull();
+  });
+
+  it('returns null after end date', () => {
+    const batch = createBatch([
+      {
+        bedId: 'bed-4',
+        assignedAt: '2026-03-01T00:00:00Z',
+        fromDate: '2026-03-01T00:00:00Z',
+        toDate: '2026-03-05T00:00:00Z',
+      },
+    ]);
+
+    expect(getActiveBedAssignment(batch, '2026-03-05T00:00:01Z')).toBeNull();
+  });
+
+  it('supports open-ended assignments', () => {
+    const batch = createBatch([{ bedId: 'bed-5', assignedAt: '2026-04-01T00:00:00Z', fromDate: '2026-04-01T00:00:00Z' }]);
+
+    expect(getActiveBedAssignment(batch, '2027-01-01T00:00:00Z')?.bedId).toBe('bed-5');
+  });
+
+  it('uses latest active fromDate when multiple assignments overlap', () => {
+    const batch = createBatch([
+      {
+        bedId: 'bed-6',
+        assignedAt: '2026-05-01T00:00:00Z',
+        fromDate: '2026-05-01T00:00:00Z',
+        toDate: '2026-05-30T00:00:00Z',
+      },
+      {
+        bedId: 'bed-7',
+        assignedAt: '2026-05-10T00:00:00Z',
+        fromDate: '2026-05-10T00:00:00Z',
+        toDate: '2026-05-25T00:00:00Z',
+      },
+    ]);
+
+    expect(getActiveBedAssignment(batch, '2026-05-15T00:00:00Z')?.bedId).toBe('bed-7');
+  });
+});

--- a/frontend/src/data/repos/batchRepository.ts
+++ b/frontend/src/data/repos/batchRepository.ts
@@ -5,17 +5,42 @@ import type { BatchListFilter, ListQuery } from './interfaces';
 
 const normalizeBatchCandidate = (value: unknown): unknown => value ?? {};
 
-const getDerivedBedId = (batch: Batch): string | null => {
-  if (batch.assignments.length === 0) {
-    return null;
+type BatchAssignmentWithRange = Batch['assignments'][number] & {
+  fromDate?: string;
+  toDate?: string | null;
+};
+
+const getAssignmentFromDate = (assignment: BatchAssignmentWithRange): string => assignment.fromDate ?? assignment.assignedAt;
+
+const getAssignmentToDate = (assignment: BatchAssignmentWithRange): string | null => assignment.toDate ?? null;
+
+export const getActiveBedAssignment = (
+  batch: Batch,
+  onDate: string,
+): BatchAssignmentWithRange | null => {
+  let activeAssignment: BatchAssignmentWithRange | null = null;
+
+  for (const assignment of batch.assignments as BatchAssignmentWithRange[]) {
+    const fromDate = getAssignmentFromDate(assignment);
+    const toDate = getAssignmentToDate(assignment);
+
+    if (fromDate > onDate) {
+      continue;
+    }
+
+    if (toDate && toDate < onDate) {
+      continue;
+    }
+
+    if (!activeAssignment || getAssignmentFromDate(activeAssignment) <= fromDate) {
+      activeAssignment = assignment;
+    }
   }
 
-  const latestAssignment = batch.assignments.reduce((latest, assignment) =>
-    assignment.assignedAt > latest.assignedAt ? assignment : latest,
-  );
-
-  return latestAssignment.bedId;
+  return activeAssignment;
 };
+
+const getDerivedBedId = (batch: Batch, onDate: string): string | null => getActiveBedAssignment(batch, onDate)?.bedId ?? null;
 
 export const getBatchFromAppState = (
   appState: unknown,
@@ -37,6 +62,7 @@ export const listBatchesFromAppState = (
 ): Batch[] => {
   const state = assertValid('appState', appState);
   const { filter } = query;
+  const onDate = new Date().toISOString();
 
   return state.batches
     .filter((batch) => {
@@ -52,7 +78,7 @@ export const listBatchesFromAppState = (
         return false;
       }
 
-      if (filter.bedId && getDerivedBedId(batch) !== filter.bedId) {
+      if (filter.bedId && getDerivedBedId(batch, onDate) !== filter.bedId) {
         return false;
       }
 


### PR DESCRIPTION
### Motivation

- Reduce duplicated "current/active bed" logic by introducing a single canonical helper that captures inclusive date-bounds semantics (`fromDate <= onDate` and `toDate` missing or `toDate >= onDate`).
- Preserve existing data contract by treating legacy `assignedAt` as the fallback `fromDate` so no schema migration is required.

### Description

- Added `getActiveBedAssignment(batch, onDate)` in `frontend/src/data/repos/batchRepository.ts` which selects the active assignment using inclusive bounds and deterministic tie-breaking (latest `fromDate`).
- Kept compatibility by treating `assignedAt` as the `fromDate` when `fromDate` is not present and supporting optional `toDate` as nullable (open-ended when missing).
- Replaced duplicated derivation in `frontend/src/App.tsx` to call the shared helper for UI display and filters (`getActiveBedAssignment(batch, new Date().toISOString())`).
- Updated `listBatchesFromAppState` to use the helper for `bedId` filtering and exported the helper via `frontend/src/data/index.ts` for shared usage.
- Added focused unit tests `frontend/src/data/repos/batchRepository.test.ts` that cover start-equals-onDate, inclusive `toDate`, before/after bounds, open-ended assignments, and overlapping assignments resolution.

### Testing

- Added unit tests in `frontend/src/data/repos/batchRepository.test.ts` covering the helper boundary cases described above (not executed as part of this patch).
- Per fast-patch constraints, no test runner was executed in this change; tests should be run with `pnpm -w test` or the project-specific `vitest` command to validate.
- Quick repository checks (`rg`/`git status`) were used to verify call sites were updated and new test file added successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a58c8afc308326be0d8d6b483fea69)