### PR TITLE
Add notes autosave and composition placeholder to bed detail

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import {
   saveAppStateToIndexedDb,
   savePhotoBlobToIndexedDb,
   upsertBatchInAppState,
+  upsertBedInAppState,
   getActiveBedAssignment,
 } from './data';
 import { applyStageEvent, canTransition } from './domain';
@@ -92,6 +93,7 @@ function BedsPage() {
 function BedDetailPage() {
   const { bedId } = useParams();
   const [bed, setBed] = useState<Bed | null>(null);
+  const [notes, setNotes] = useState('');
   const [batches, setBatches] = useState<Batch[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -118,12 +120,52 @@ function BedDetailPage() {
         .sort((left, right) => left.batchId.localeCompare(right.batchId));
 
       setBed(nextBed);
+      setNotes(nextBed?.notes ?? '');
       setBatches(relatedBatches);
       setIsLoading(false);
     };
 
     void load();
   }, [bedId]);
+
+  useEffect(() => {
+    if (!bed || !bedId) {
+      return;
+    }
+
+    if ((bed.notes ?? '') === notes) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      const persistNotes = async () => {
+        const appState = await loadAppStateFromIndexedDb();
+        if (!appState) {
+          return;
+        }
+
+        const latestBed = listBedsFromAppState(appState).find((candidate) => candidate.bedId === bedId);
+        if (!latestBed) {
+          return;
+        }
+
+        const nextState = upsertBedInAppState(appState, {
+          ...latestBed,
+          notes,
+          updatedAt: new Date().toISOString(),
+        });
+
+        await saveAppStateToIndexedDb(nextState);
+        setBed((current) => (current && current.bedId === bedId ? { ...current, notes } : current));
+      };
+
+      void persistNotes();
+    }, 600);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [bed, bedId, notes]);
 
   if (isLoading) {
     return <p className="beds-empty-state">Loading bed…</p>;
@@ -148,6 +190,27 @@ function BedDetailPage() {
       </Link>
       <h2>{bed.name}</h2>
       <p className="bed-detail-meta">{bed.bedId} · Garden {bed.gardenId}</p>
+
+      <article className="bed-detail-card">
+        <h3>Details</h3>
+        <p className="bed-detail-meta">Area: —</p>
+
+        <label className="bed-detail-notes-label" htmlFor="bed-notes">
+          Notes
+        </label>
+        <textarea
+          id="bed-notes"
+          className="bed-detail-notes-input"
+          value={notes}
+          onChange={(event) => setNotes(event.target.value)}
+          placeholder="Add bed notes..."
+        />
+      </article>
+
+      <article className="bed-detail-card">
+        <h3>Composition</h3>
+        <p className="bed-detail-meta">Companions and succession notes will appear here.</p>
+      </article>
 
       <article className="bed-detail-card">
         <h3>Active batches</h3>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -149,6 +149,22 @@ body {
   font-weight: 600;
 }
 
+.bed-detail-notes-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #374151;
+}
+
+.bed-detail-notes-input {
+  width: 100%;
+  min-height: 7rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.45rem;
+  padding: 0.5rem 0.6rem;
+  font: inherit;
+  resize: vertical;
+}
+
 .batches-page {
   width: min(900px, 100%);
   margin: 0 auto;


### PR DESCRIPTION
### Motivation
- Provide an editable notes area on the bed detail view so users can capture freeform bed-level notes and persist them to app state. 
- Keep the bed detail route fast to load while performing persistence in the background via autosave. 
- Reserve a placeholder area for future composition/companion/succession content without changing domain logic or schemas.

### Description
- Updated `BedDetailPage` in `frontend/src/App.tsx` to initialize and manage a local `notes` state for the current bed and reset it when the `bedId` changes. 
- Implemented a debounced autosave (600ms) that reads the latest app state with `loadAppStateFromIndexedDb`, merges the updated bed via `upsertBedInAppState`, and persists with `saveAppStateToIndexedDb` without blocking render. 
- Added new UI sections in the bed detail: a `Details` card (shows `Area: —` fallback and the notes `textarea`) and a `Composition` placeholder card. 
- Added minimal styles for the notes label and textarea in `frontend/src/index.css` using `.bed-detail-notes-label` and `.bed-detail-notes-input`.

### Testing
- No automated tests were run as part of this fast patch (no build/CI step executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a59153273083268fd0d69024c33108)