### PR TITLE
Enhance bed detail active batch presentation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -95,6 +95,8 @@ function BedDetailPage() {
   const [bed, setBed] = useState<Bed | null>(null);
   const [notes, setNotes] = useState('');
   const [batches, setBatches] = useState<Batch[]>([]);
+  const [cropNames, setCropNames] = useState<Record<string, string>>({});
+  const [cropScientificNames, setCropScientificNames] = useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -110,13 +112,27 @@ function BedDetailPage() {
       if (!appState) {
         setBed(null);
         setBatches([]);
+        setCropNames({});
+        setCropScientificNames({});
         setIsLoading(false);
         return;
       }
 
+      setCropNames(Object.fromEntries(appState.crops.map((crop) => [crop.cropId, crop.name])));
+      setCropScientificNames(
+        Object.fromEntries(
+          appState.crops.map((crop) => {
+            const scientificName = (crop as { scientificName?: string }).scientificName;
+            return [crop.cropId, scientificName ?? ''];
+          }),
+        ),
+      );
+
+      const todayIso = new Date().toISOString();
+
       const nextBed = listBedsFromAppState(appState).find((candidate) => candidate.bedId === bedId) ?? null;
       const relatedBatches = listBatchesFromAppState(appState)
-        .filter((batch) => getDerivedBedId(batch) === bedId)
+        .filter((batch) => getActiveBedAssignment(batch, todayIso)?.bedId === bedId)
         .sort((left, right) => left.batchId.localeCompare(right.batchId));
 
       setBed(nextBed);
@@ -220,8 +236,14 @@ function BedDetailPage() {
           <ul className="bed-detail-batch-list">
             {batches.map((batch) => (
               <li key={batch.batchId}>
-                <Link to={`/batches/${batch.batchId}`}>{batch.batchId}</Link>
-                <span>{batch.stage}</span>
+                <Link to={`/batches/${batch.batchId}`}>
+                  {formatCropOptionLabel({
+                    cropId: batch.cropId,
+                    name: cropNames[batch.cropId],
+                    scientificName: cropScientificNames[batch.cropId],
+                  }) || batch.cropId || batch.batchId}
+                </Link>
+                <span className="batch-stage-badge">{batch.stage}</span>
               </li>
             ))}
           </ul>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -134,18 +134,14 @@ body {
 .bed-detail-batch-list li {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   gap: 0.75rem;
 }
 
 .bed-detail-batch-list a {
   color: #1d4ed8;
   text-decoration: none;
-}
-
-.bed-detail-batch-list span {
-  text-transform: capitalize;
-  color: #374151;
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   font-weight: 600;
 }
 


### PR DESCRIPTION
### Motivation
- Improve the Bed detail view to show meaningful active batch information (crop display name and stage) for the current day while preserving existing empty/loading behavior.
- Use the domain helper that derives active bed assignments so row visibility matches the app's assignment rules for “today”.

### Description
- In `BedDetailPage` (`frontend/src/App.tsx`) add `cropNames` and `cropScientificNames` state and populate them from `appState.crops` to build fast lookup maps for display labels.
- Filter batches for the current bed using `getActiveBedAssignment(batch, todayIso)?.bedId` (where `todayIso` is `new Date().toISOString()`), while still listing batches from `listBatchesFromAppState`.
- Render each active batch row as a link to `/batches/:batchId` showing a crop label produced by `formatCropOptionLabel` (with safe fallback to `cropId` or `batchId`) and the batch `stage` styled with the existing `.batch-stage-badge` class.
- Apply minimal CSS tweaks in `frontend/src/index.css` to align batch rows (`align-items: center`) and emphasize the link font sizing/weight so the new labels visually match existing batch badges.

### Testing
- Attempted a headless browser screenshot via Playwright against common local dev ports to visually validate the Bed detail page, but the requests failed with `ERR_EMPTY_RESPONSE` because no local dev server was running, so the visual test could not complete.
- No automated unit tests were added or modified for this presentation-only change and no build/test suite was executed as part of this fast patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a592ebf6dc83269142a07d33cb1d37)