### PR TITLE
Add remove-from-bed action for batches with idempotent behavior

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import {
   upsertBatchInAppState,
   upsertBedInAppState,
   getActiveBedAssignment,
+  removeBatchFromBed,
 } from './data';
 import { applyStageEvent, canTransition } from './domain';
 
@@ -742,6 +743,9 @@ function BatchDetailPage() {
   const [cropName, setCropName] = useState<string | null>(null);
   const [actionDates, setActionDates] = useState<Record<string, string>>({});
   const [stageActionMessage, setStageActionMessage] = useState<string | null>(null);
+  const [removeFromBedDate, setRemoveFromBedDate] = useState(getLocalDateTimeDefault());
+  const [removeFromBedMessage, setRemoveFromBedMessage] = useState<string | null>(null);
+  const [isSavingRemoveFromBed, setIsSavingRemoveFromBed] = useState(false);
   const [isSavingStageAction, setIsSavingStageAction] = useState(false);
   const [photoActionMessage, setPhotoActionMessage] = useState<string | null>(null);
   const [isSavingPhoto, setIsSavingPhoto] = useState(false);
@@ -786,6 +790,8 @@ function BatchDetailPage() {
         ended: dateDefault,
       });
       setStageActionMessage(null);
+      setRemoveFromBedDate(dateDefault);
+      setRemoveFromBedMessage(null);
       setPhotoActionMessage(null);
       setExpandedPhotoIds({});
       setIsLoading(false);
@@ -914,6 +920,42 @@ function BatchDetailPage() {
       setStageActionMessage(message);
     } finally {
       setIsSavingStageAction(false);
+    }
+  };
+
+
+  const handleRemoveFromBed = async () => {
+    if (!batch || !batchId) {
+      return;
+    }
+
+    if (!removeFromBedDate) {
+      setRemoveFromBedMessage('Enter a valid date and time before removing from bed.');
+      return;
+    }
+
+    const endDate = new Date(removeFromBedDate).toISOString();
+    const nextBatch = removeBatchFromBed(batch, endDate);
+
+    setIsSavingRemoveFromBed(true);
+
+    try {
+      const appState = await loadAppStateFromIndexedDb();
+      if (!appState) {
+        setRemoveFromBedMessage('Unable to save because local app state is unavailable.');
+        return;
+      }
+
+      const nextState = upsertBatchInAppState(appState, nextBatch);
+      await saveAppStateToIndexedDb(nextState);
+      const refreshedBatch = nextState.batches.find((candidate) => candidate.batchId === batchId) ?? null;
+      setBatch(refreshedBatch);
+      setRemoveFromBedMessage(nextBatch === batch ? 'Batch is already unassigned for that date.' : 'Batch removed from bed.');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to remove batch from bed.';
+      setRemoveFromBedMessage(message);
+    } finally {
+      setIsSavingRemoveFromBed(false);
     }
   };
 
@@ -1167,6 +1209,18 @@ function BatchDetailPage() {
       <article className="batch-detail-card">
         <h3>Bed assignments</h3>
         <p className="batch-detail-current-bed">Current: {getDerivedBedId(batch) ?? 'Unassigned'}</p>
+        <div className="batch-next-action-row">
+          <span className="batch-detail-pill">remove</span>
+          <input
+            type="datetime-local"
+            value={removeFromBedDate}
+            onChange={(event) => setRemoveFromBedDate(event.target.value)}
+          />
+          <button type="button" onClick={() => void handleRemoveFromBed()} disabled={isSavingRemoveFromBed}>
+            Remove from bed
+          </button>
+        </div>
+        {removeFromBedMessage ? <p className="batch-stage-warning">{removeFromBedMessage}</p> : null}
         {assignmentHistory.length === 0 ? (
           <p className="batch-detail-empty">No bed assignment history.</p>
         ) : (

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -25,6 +25,7 @@ export {
   getBatchFromAppState,
   listBatchesFromAppState,
   moveBatch,
+  removeBatchFromBed,
   removeBatchFromAppState,
   upsertBatchInAppState,
 } from './repos/batchRepository';

--- a/frontend/src/data/repos/batchRepository.test.ts
+++ b/frontend/src/data/repos/batchRepository.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Batch } from '../../contracts';
-import { assignBatchToBed, getActiveBedAssignment, moveBatch } from './batchRepository';
+import { assignBatchToBed, getActiveBedAssignment, moveBatch, removeBatchFromBed } from './batchRepository';
 
 const createBatch = (assignments: Array<{ bedId: string; assignedAt: string; fromDate?: string; toDate?: string | null }>): Batch =>
   ({
@@ -189,5 +189,43 @@ describe('moveBatch', () => {
     ]);
 
     expect(() => moveBatch(batch, 'bed-2', '2026-01-09T00:00:00Z')).toThrowError('batch_assignment_no_active');
+  });
+});
+
+
+describe('removeBatchFromBed', () => {
+  it('closes active assignment and leaves no active assignment after end date', () => {
+    const batch = createBatch([
+      {
+        bedId: 'bed-1',
+        assignedAt: '2026-01-01T00:00:00Z',
+        fromDate: '2026-01-01T00:00:00Z',
+      },
+    ]);
+
+    const updated = removeBatchFromBed(batch, '2026-01-15T00:00:00Z');
+
+    expect(updated.assignments).toHaveLength(1);
+    expect(updated.assignments[0]).toMatchObject({
+      bedId: 'bed-1',
+      toDate: '2026-01-15T00:00:00Z',
+    });
+    expect(getActiveBedAssignment(updated, '2026-01-15T00:00:01Z')).toBeNull();
+  });
+
+  it('returns unchanged batch when already unassigned at end date', () => {
+    const batch = createBatch([
+      {
+        bedId: 'bed-1',
+        assignedAt: '2026-01-01T00:00:00Z',
+        fromDate: '2026-01-01T00:00:00Z',
+        toDate: '2026-01-05T00:00:00Z',
+      },
+    ]);
+
+    const updated = removeBatchFromBed(batch, '2026-01-10T00:00:00Z');
+
+    expect(updated).toBe(batch);
+    expect(getActiveBedAssignment(updated, '2026-01-10T00:00:01Z')).toBeNull();
   });
 });

--- a/frontend/src/data/repos/batchRepository.ts
+++ b/frontend/src/data/repos/batchRepository.ts
@@ -151,6 +151,28 @@ export const moveBatch = (
   };
 };
 
+export const removeBatchFromBed = (batch: Batch, endDate: string): Batch => {
+  const activeAssignment = getActiveBedAssignment(batch, endDate);
+
+  if (!activeAssignment) {
+    return batch;
+  }
+
+  return {
+    ...batch,
+    assignments: (batch.assignments as BatchAssignmentWithRange[]).map((assignment) => {
+      if (assignment !== activeAssignment) {
+        return assignment;
+      }
+
+      return {
+        ...assignment,
+        toDate: endDate,
+      };
+    }) as Batch['assignments'],
+  };
+};
+
 const getDerivedBedId = (batch: Batch, onDate: string): string | null => getActiveBedAssignment(batch, onDate)?.bedId ?? null;
 
 export const getBatchFromAppState = (


### PR DESCRIPTION
### Motivation
- Provide a simple, low-risk way to end a batch's current bed assignment without deleting history by setting an assignment `toDate` at a chosen end timestamp.
- Ensure the operation is idempotent when there is no active assignment at the chosen date so the UI can offer a neutral, non-error UX.

### Description
- Added `removeBatchFromBed(batch, endDate)` in `frontend/src/data/repos/batchRepository.ts` which finds the active assignment at `endDate` and sets its `toDate` to `endDate`, returning the original batch unchanged when none is active.
- Exported `removeBatchFromBed` from `frontend/src/data/index.ts` so it is available via the existing data barrel.
- Added a minimal UI in `BatchDetailPage` (`frontend/src/App.tsx`) consisting of a `datetime-local` input (defaulting to now) and a `Remove from bed` button that calls the new helper and persists the updated batch using the existing `upsertBatchInAppState` + `saveAppStateToIndexedDb` flow, with neutral messaging for idempotent cases.
- Extended repository unit tests in `frontend/src/data/repos/batchRepository.test.ts` to cover (a) closing an active assignment and asserting no active assignment remains just after the `endDate`, and (b) the already-unassigned idempotent path returning the original batch.

### Testing
- No automated unit tests were executed in this environment; new tests were added under `describe('removeBatchFromBed', ...)` in `frontend/src/data/repos/batchRepository.test.ts` but were not run here.
- An automated Playwright-based screenshot attempt was executed against local dev hosts and failed with `ERR_EMPTY_RESPONSE` for all targets, so no UI verification was produced.
- Recommend running the test suite locally (for example `pnpm --filter frontend test`) and exercising the `BatchDetailPage` UI in a running dev server to validate the persisted change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5ad38d5fc8326894d8a7871aee84d)