### PR TITLE
Add task-rule contract support and deterministic window expansion helper

### DIFF
--- a/frontend/src/contracts/crop.schema.json
+++ b/frontend/src/contracts/crop.schema.json
@@ -66,6 +66,13 @@
         }
       }
     },
+    "taskRules": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/taskRuleSection"
+      }
+    },
     "nutritionProfile": {
       "type": "array",
       "minItems": 1,
@@ -89,6 +96,22 @@
     "isoDate": {
       "type": "string",
       "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?Z$"
+    },
+    "localDate": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "taskType": {
+      "type": "string",
+      "enum": [
+        "pre_sow",
+        "pot_up",
+        "harden_off",
+        "transplant",
+        "direct_sow",
+        "harvest",
+        "preserve"
+      ]
     },
     "windowRange": {
       "type": "object",
@@ -119,6 +142,81 @@
           "type": "integer",
           "minimum": 1,
           "maximum": 5
+        }
+      }
+    },
+    "windowDateRange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "startDate",
+        "endDate"
+      ],
+      "properties": {
+        "startDate": {
+          "$ref": "#/$defs/localDate"
+        },
+        "endDate": {
+          "$ref": "#/$defs/localDate"
+        }
+      }
+    },
+    "windowMonthWeek": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "month",
+        "weekIndex"
+      ],
+      "properties": {
+        "month": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 12
+        },
+        "weekIndex": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 5
+        }
+      }
+    },
+    "taskRuleWindow": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/windowDateRange"
+        },
+        {
+          "$ref": "#/$defs/windowMonthWeek"
+        }
+      ]
+    },
+    "taskRuleSection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "taskType",
+        "sequence",
+        "windows"
+      ],
+      "properties": {
+        "taskType": {
+          "$ref": "#/$defs/taskType"
+        },
+        "sequence": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "windows": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/taskRuleWindow"
+          }
+        },
+        "notes": {
+          "type": "string",
+          "maxLength": 500
         }
       }
     },

--- a/frontend/src/contracts/crop.schema.test.ts
+++ b/frontend/src/contracts/crop.schema.test.ts
@@ -31,6 +31,18 @@ describe('crop.schema.json', () => {
         notes: 'Room temperature for short-term storage',
       },
     },
+    taskRules: [
+      {
+        taskType: 'pre_sow',
+        sequence: 1,
+        windows: [{ month: 2, weekIndex: 2 }],
+      },
+      {
+        taskType: 'transplant',
+        sequence: 2,
+        windows: [{ startDate: '2026-04-01', endDate: '2026-04-21' }],
+      },
+    ],
     nutritionProfile: [
       {
         nutrient: 'Vitamin C',
@@ -80,6 +92,21 @@ describe('crop.schema.json', () => {
           unit: 'grams',
           source: '',
           assumptions: '',
+        },
+      ],
+    };
+
+    expect(validate(payload)).toBe(false);
+  });
+
+  it('rejects invalid task rule task types and window shapes', () => {
+    const payload = {
+      ...validPayload,
+      taskRules: [
+        {
+          taskType: 'sowing',
+          sequence: 1,
+          windows: [{ month: 2 }],
         },
       ],
     };

--- a/frontend/src/domain/index.test.ts
+++ b/frontend/src/domain/index.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { expandTaskRuleWindowsToLocalDates } from './index';
+
+describe('expandTaskRuleWindowsToLocalDates', () => {
+  it('returns deterministic local dates for mixed window formats', () => {
+    const windows = [
+      { startDate: '2026-03-01', endDate: '2026-03-11' },
+      { month: 4, weekIndex: 2 },
+      { month: 4, weekIndex: 2 },
+    ];
+
+    const first = expandTaskRuleWindowsToLocalDates(windows, 2026);
+    const second = expandTaskRuleWindowsToLocalDates(windows, 2026);
+
+    expect(first).toEqual(['2026-03-06', '2026-04-08']);
+    expect(second).toEqual(first);
+  });
+
+  it('clamps out-of-range month week selections deterministically', () => {
+    expect(expandTaskRuleWindowsToLocalDates([{ month: 2, weekIndex: 5 }], 2026)).toEqual([
+      '2026-02-22',
+    ]);
+  });
+});

--- a/frontend/src/domain/index.ts
+++ b/frontend/src/domain/index.ts
@@ -58,3 +58,61 @@ export const applyStageEvent = (batch: Batch, event: BatchStageEvent): BatchTran
     },
   };
 };
+
+export type TaskRuleDateRangeWindow = {
+  startDate: string;
+  endDate: string;
+};
+
+export type TaskRuleMonthWeekWindow = {
+  month: number;
+  weekIndex: number;
+};
+
+export type TaskRuleWindow = TaskRuleDateRangeWindow | TaskRuleMonthWeekWindow;
+
+const LOCAL_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+const toUtcDate = (localDate: string): Date => {
+  const parsed = LOCAL_DATE_PATTERN.exec(localDate);
+
+  if (!parsed) {
+    throw new Error(`Invalid local date: ${localDate}`);
+  }
+
+  const [, year, month, day] = parsed;
+  return new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)));
+};
+
+const toLocalDate = (date: Date): string => date.toISOString().slice(0, 10);
+
+const expandDateRangeWindowToLocalDate = (window: TaskRuleDateRangeWindow): string => {
+  const start = toUtcDate(window.startDate);
+  const end = toUtcDate(window.endDate);
+
+  if (end.getTime() <= start.getTime()) {
+    return window.startDate;
+  }
+
+  const midpointTime = start.getTime() + Math.floor((end.getTime() - start.getTime()) / 2);
+  return toLocalDate(new Date(midpointTime));
+};
+
+const expandMonthWeekWindowToLocalDate = (window: TaskRuleMonthWeekWindow, year: number): string => {
+  const daysInMonth = new Date(Date.UTC(year, window.month, 0)).getUTCDate();
+  const maxWeekIndex = Math.ceil(daysInMonth / 7);
+  const clampedWeekIndex = Math.min(Math.max(window.weekIndex, 1), maxWeekIndex);
+  const day = 1 + (clampedWeekIndex - 1) * 7;
+
+  return toLocalDate(new Date(Date.UTC(year, window.month - 1, day)));
+};
+
+export const expandTaskRuleWindowsToLocalDates = (windows: TaskRuleWindow[], year: number): string[] => {
+  const dates = windows.map((window) =>
+    'startDate' in window
+      ? expandDateRangeWindowToLocalDate(window)
+      : expandMonthWeekWindowToLocalDate(window, year),
+  );
+
+  return [...new Set(dates)].sort();
+};

--- a/frontend/src/generated/contracts.ts
+++ b/frontend/src/generated/contracts.ts
@@ -45,6 +45,34 @@ export interface CropRuleSection {
   notes?: string;
 }
 
+export type CropTaskType =
+  | 'pre_sow'
+  | 'pot_up'
+  | 'harden_off'
+  | 'transplant'
+  | 'direct_sow'
+  | 'harvest'
+  | 'preserve';
+
+export interface CropTaskRuleDateRangeWindow {
+  startDate: string;
+  endDate: string;
+}
+
+export interface CropTaskRuleMonthWeekWindow {
+  month: number;
+  weekIndex: number;
+}
+
+export type CropTaskRuleWindow = CropTaskRuleDateRangeWindow | CropTaskRuleMonthWeekWindow;
+
+export interface CropTaskRuleSection {
+  taskType: CropTaskType;
+  sequence: number;
+  windows: CropTaskRuleWindow[];
+  notes?: string;
+}
+
 export interface CropNutritionItem {
   nutrient: string;
   value: number;
@@ -65,6 +93,7 @@ export interface Crop {
     harvest: CropRuleSection;
     storage: CropRuleSection;
   };
+  taskRules?: CropTaskRuleSection[];
   nutritionProfile: CropNutritionItem[];
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
### Motivation
- Provide a minimal, deterministic rule model to generate scheduled tasks (pre_sow, pot_up, harden_off, transplant, direct_sow, harvest, preserve) while keeping existing rule shapes intact.
- Represent windows in local-date-only terms and a compact month/week shape to avoid timezone/timestamp ambiguity and enable deterministic expansion.

### Description
- Extend the crop contract JSON with `taskRules`, a `taskType` enum, and new window shapes (`{startDate,endDate}` and `{month,weekIndex}`) in `frontend/src/contracts/crop.schema.json`.
- Update committed generated TypeScript contracts to include the new types and optional `Crop.taskRules` in `frontend/src/generated/contracts.ts`.
- Add a deterministic expansion helper `expandTaskRuleWindowsToLocalDates` (with `TaskRuleWindow` types) to `frontend/src/domain/index.ts` that expands date-range windows to their midpoint and month/week windows to a clamped week start as local `YYYY-MM-DD` strings.
- Add unit tests for deterministic expansion and schema validation updates in `frontend/src/domain/index.test.ts` and `frontend/src/contracts/crop.schema.test.ts`.

### Testing
- No automated test suite was executed as part of this patch; only unit tests were added or updated.
- Added a unit test file `frontend/src/domain/index.test.ts` that asserts deterministic expansion for mixed window formats and week-index clamping.
- Updated `frontend/src/contracts/crop.schema.test.ts` to cover the new `taskRules` shapes and invalid-shape rejection cases.
- These tests can be run locally with the frontend test runner (for example `pnpm --filter frontend test`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5b68007ec832695e8ac239a4a34f4)