### PR TITLE
Add deterministic planned task generation from crop plans

### DIFF
--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -43,6 +43,7 @@ export {
   saveSettingsInAppState,
 } from './repos/settingsRepository';
 export {
+  generatePlannedTasks,
   getTaskFromAppState,
   listTasksFromAppState,
   removeTaskFromAppState,

--- a/frontend/src/data/repos/taskRepository.ts
+++ b/frontend/src/data/repos/taskRepository.ts
@@ -1,4 +1,5 @@
 import type { AppState, Task } from '../../contracts';
+import { expandTaskRuleWindowsToLocalDates } from '../../domain';
 import { assertValid } from '../validation';
 import type { ListQuery } from './interfaces';
 
@@ -87,4 +88,103 @@ export const upsertGeneratedTasksInAppState = (
     ...state,
     tasks: [...mergedTasksBySourceKey.values()],
   });
+};
+
+const buildPlannedTaskSourceKey = (
+  year: number,
+  bedId: string,
+  cropId: string,
+  successionIndex: number,
+  taskType: string,
+  windowIndex: number,
+): string =>
+  ['plan', year, bedId, cropId, successionIndex, taskType, windowIndex]
+    .join('_')
+    .toLowerCase();
+
+const toTaskType = (taskType: string): string => taskType.replace(/_/g, '-');
+
+export const generatePlannedTasks = (appState: unknown, year: number): Task[] => {
+  const state = assertValid('appState', appState);
+  const cropsById = new Map(state.crops.map((crop) => [crop.cropId, crop]));
+  const sortedPlans = [...state.cropPlans]
+    .filter((plan) => plan.seasonYear === year && typeof plan.bedId === 'string' && plan.bedId.length > 0)
+    .sort((left, right) =>
+      left.bedId === right.bedId
+        ? left.cropId === right.cropId
+          ? left.planId.localeCompare(right.planId)
+          : left.cropId.localeCompare(right.cropId)
+        : left.bedId!.localeCompare(right.bedId!),
+    );
+
+  const successionIndexByPlanId = new Map<string, number>();
+  const successionCounters = new Map<string, number>();
+
+  for (const plan of sortedPlans) {
+    const key = `${plan.bedId}:${plan.cropId}`;
+    const nextIndex = (successionCounters.get(key) ?? -1) + 1;
+    successionCounters.set(key, nextIndex);
+    successionIndexByPlanId.set(plan.planId, nextIndex);
+  }
+
+  const plannedTasks: Task[] = [];
+
+  for (const plan of sortedPlans) {
+    const crop = cropsById.get(plan.cropId);
+
+    if (!crop || !crop.taskRules || crop.taskRules.length === 0 || !plan.bedId) {
+      continue;
+    }
+
+    const sortedTaskRules = [...crop.taskRules].sort((left, right) =>
+      left.sequence === right.sequence
+        ? left.taskType.localeCompare(right.taskType)
+        : left.sequence - right.sequence,
+    );
+
+    const successionIndex = successionIndexByPlanId.get(plan.planId);
+
+    if (typeof successionIndex !== 'number') {
+      continue;
+    }
+
+    for (const taskRule of sortedTaskRules) {
+      const windowsWithIndex = taskRule.windows.map((window, windowIndex) => ({ window, windowIndex }));
+
+      for (const { window, windowIndex } of windowsWithIndex) {
+        const [date] = expandTaskRuleWindowsToLocalDates([window], year);
+
+        if (!date) {
+          continue;
+        }
+
+        const sourceKey = buildPlannedTaskSourceKey(
+          year,
+          plan.bedId,
+          plan.cropId,
+          successionIndex,
+          taskRule.taskType,
+          windowIndex,
+        );
+
+        plannedTasks.push({
+          id: sourceKey,
+          sourceKey,
+          date,
+          type: toTaskType(taskRule.taskType),
+          cropId: plan.cropId,
+          bedId: plan.bedId,
+          batchId: `planned_${year}_${plan.bedId}_${plan.cropId}_${successionIndex}`.toLowerCase(),
+          checklist: [],
+          status: 'pending',
+        });
+      }
+    }
+  }
+
+  return plannedTasks.sort((left, right) =>
+    left.date === right.date
+      ? left.sourceKey.localeCompare(right.sourceKey)
+      : left.date.localeCompare(right.date),
+  );
 };

--- a/frontend/src/data/validation/index.test.ts
+++ b/frontend/src/data/validation/index.test.ts
@@ -25,6 +25,7 @@ import {
   upsertTaskInAppState,
   removeTaskFromAppState,
   upsertGeneratedTasksInAppState,
+  generatePlannedTasks,
   getSeedInventoryItemFromAppState,
   listSeedInventoryItemsFromAppState,
   upsertSeedInventoryItemInAppState,
@@ -599,6 +600,39 @@ describe('task repository boundary helpers', () => {
 
     const removed = removeTaskFromAppState(upserted, updatedTask.id);
     expect(getTaskFromAppState(removed, updatedTask.id)).toBeNull();
+  });
+});
+
+describe('planned task generation', () => {
+  it('returns deterministic planned tasks for the golden fixture', () => {
+    const fixture = goldenFixtures['../../../../fixtures/golden/trier-v1.json'];
+
+    const first = generatePlannedTasks(fixture, 2026);
+    const second = generatePlannedTasks(fixture, 2026);
+
+    expect(first).toEqual(second);
+    expect(first.map((task) => task.sourceKey)).toEqual([...first.map((task) => task.sourceKey)].sort());
+    expect(first.every((task) =>
+      /^plan_2026_[a-z0-9-]+_[a-z0-9-]+_\d+_[a-z_]+_\d+$/.test(task.sourceKey),
+    )).toBe(true);
+  });
+
+  it('skips crop plans that cannot resolve crop task rules', () => {
+    const tasks = generatePlannedTasks(
+      {
+        ...validAppState,
+        cropPlans: [
+          {
+            ...validCropPlan,
+            cropId: 'missing-crop',
+            seasonYear: 2026,
+          },
+        ],
+      },
+      2026,
+    );
+
+    expect(tasks).toEqual([]);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Calendar needs to generate presentation-only planned tasks without relying on batches so planning UIs can show expected work for a season.
- Planned tasks must use a stable `sourceKey` format so repeated generation is deterministic and merges behave correctly downstream.
- Generation must skip incomplete plans (missing crop/rules) rather than invent data and must not change persistence/scoring semantics.

### Description
- Add `generatePlannedTasks(appState, year)` to `frontend/src/data/repos/taskRepository.ts` to produce planned tasks from `cropPlans` + `crop.taskRules` while leaving existing persistence and merge logic untouched.
- Construct stable `sourceKey` values using the tuple `(year, bedId, cropId, successionIndex, taskType, windowIndex)` and normalize casing with `buildPlannedTaskSourceKey` for determinism.
- Ensure deterministic ordering by sorting crop plans, successional indices, task rules, and final tasks (sorted by `date` then `sourceKey`), and skip plans that cannot resolve a crop or task rules.
- Export the new generator from the data boundary (`frontend/src/data/index.ts`) and add unit tests in `frontend/src/data/validation/index.test.ts` covering golden-fixture determinism and skip behavior for unresolved crops.

### Testing
- Added unit tests in `frontend/src/data/validation/index.test.ts` that assert deterministic output against the golden fixture and that plans missing crop rules are skipped; these are automated `vitest` tests.
- No test runner was executed as part of this change; the tests were added but not run in this PR.
- The change is presentation-only and does not mutate persistence or scoring behavior, so existing repository boundary tests remain unaffected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5b78198448326950e6f3c7ed4f5cd)