### PR TITLE
Add deterministic operational task generation from batch timelines

### DIFF
--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -43,6 +43,7 @@ export {
   saveSettingsInAppState,
 } from './repos/settingsRepository';
 export {
+  generateOperationalTasks,
   generatePlannedTasks,
   getTaskFromAppState,
   listTasksFromAppState,

--- a/frontend/src/data/repos/taskRepository.ts
+++ b/frontend/src/data/repos/taskRepository.ts
@@ -104,6 +104,39 @@ const buildPlannedTaskSourceKey = (
 
 const toTaskType = (taskType: string): string => taskType.replace(/_/g, '-');
 
+const toIsoDate = (isoDateTime: string): string => isoDateTime.slice(0, 10);
+
+const addDays = (isoDate: string, days: number): string => {
+  const date = new Date(`${isoDate}T00:00:00Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+};
+
+const sortStageEvents = (events: AppState['batches'][number]['stageEvents']) =>
+  events
+    .map((event, index) => ({ ...event, index }))
+    .sort((left, right) =>
+      left.occurredAt === right.occurredAt
+        ? left.index - right.index
+        : left.occurredAt.localeCompare(right.occurredAt),
+    );
+
+const selectLatestStageEvent = (
+  events: AppState['batches'][number]['stageEvents'],
+  ...stageNames: string[]
+) => {
+  const normalizedStageNames = new Set(stageNames.map((stageName) => stageName.toLowerCase()));
+  const matchingEvents = sortStageEvents(events).filter((event) => normalizedStageNames.has(event.stage.toLowerCase()));
+  return matchingEvents.length > 0 ? matchingEvents[matchingEvents.length - 1] : null;
+};
+
+const buildOperationalTaskSourceKey = (
+  batchId: string,
+  taskType: string,
+  anchorOccurredAt: string,
+  stageEventIndex: number,
+): string => ['batch', batchId, taskType, anchorOccurredAt, stageEventIndex].join('_').toLowerCase();
+
 export const generatePlannedTasks = (appState: unknown, year: number): Task[] => {
   const state = assertValid('appState', appState);
   const cropsById = new Map(state.crops.map((crop) => [crop.cropId, crop]));
@@ -183,6 +216,74 @@ export const generatePlannedTasks = (appState: unknown, year: number): Task[] =>
   }
 
   return plannedTasks.sort((left, right) =>
+    left.date === right.date
+      ? left.sourceKey.localeCompare(right.sourceKey)
+      : left.date.localeCompare(right.date),
+  );
+};
+
+export const generateOperationalTasks = (appState: unknown): Task[] => {
+  const state = assertValid('appState', appState);
+  const cropsById = new Map(state.crops.map((crop) => [crop.cropId, crop]));
+  const generatedTasks: Task[] = [];
+
+  for (const batch of state.batches) {
+    const latestAssignment = batch.assignments.length > 0 ? batch.assignments[batch.assignments.length - 1] : null;
+    const bedId = latestAssignment?.bedId ?? 'unassigned';
+    const preSown = selectLatestStageEvent(batch.stageEvents, 'pre_sown', 'sowing');
+    const germinated = selectLatestStageEvent(batch.stageEvents, 'germinated');
+    const transplant = selectLatestStageEvent(batch.stageEvents, 'transplant');
+    const harvest = selectLatestStageEvent(batch.stageEvents, 'harvest');
+    const crop = cropsById.get(batch.cropId);
+
+    const pushTask = (taskType: string, date: string, anchorOccurredAt: string, stageEventIndex: number) => {
+      const sourceKey = buildOperationalTaskSourceKey(batch.batchId, taskType, anchorOccurredAt, stageEventIndex);
+      generatedTasks.push({
+        id: sourceKey,
+        sourceKey,
+        date,
+        type: taskType,
+        cropId: batch.cropId,
+        bedId,
+        batchId: batch.batchId,
+        checklist: [],
+        status: 'pending',
+      });
+    };
+
+    if (preSown) {
+      const anchorDate = toIsoDate(preSown.occurredAt);
+      pushTask('germination-check', addDays(anchorDate, 7), preSown.occurredAt, preSown.index);
+      pushTask('germination-check', addDays(anchorDate, 14), preSown.occurredAt, preSown.index + 1);
+    }
+
+    if (germinated) {
+      pushTask('pot-up', addDays(toIsoDate(germinated.occurredAt), 7), germinated.occurredAt, germinated.index);
+    }
+
+    if (transplant) {
+      const transplantDate = toIsoDate(transplant.occurredAt);
+      pushTask('harden-off', addDays(transplantDate, -7), transplant.occurredAt, transplant.index);
+      pushTask('harden-off', addDays(transplantDate, -2), transplant.occurredAt, transplant.index + 1);
+      pushTask('bed-assignment', transplantDate, transplant.occurredAt, transplant.index + 2);
+
+      const harvestWindowDates = crop?.taskRules
+        ?.filter((rule) => rule.taskType === 'harvest')
+        .flatMap((rule) => expandTaskRuleWindowsToLocalDates(rule.windows, Number.parseInt(transplantDate.slice(0, 4), 10)))
+        .sort();
+
+      if (harvestWindowDates && harvestWindowDates.length > 0) {
+        const firstAfterTransplant = harvestWindowDates.find((date) => date >= transplantDate) ?? harvestWindowDates[0];
+        pushTask('harvest-reminder', firstAfterTransplant, transplant.occurredAt, transplant.index + 3);
+      } else {
+        pushTask('harvest-reminder', addDays(transplantDate, 60), transplant.occurredAt, transplant.index + 3);
+      }
+    } else if (harvest) {
+      pushTask('harvest-reminder', toIsoDate(harvest.occurredAt), harvest.occurredAt, harvest.index);
+    }
+  }
+
+  return generatedTasks.sort((left, right) =>
     left.date === right.date
       ? left.sourceKey.localeCompare(right.sourceKey)
       : left.date.localeCompare(right.date),

--- a/frontend/src/data/validation/index.test.ts
+++ b/frontend/src/data/validation/index.test.ts
@@ -25,6 +25,7 @@ import {
   upsertTaskInAppState,
   removeTaskFromAppState,
   upsertGeneratedTasksInAppState,
+  generateOperationalTasks,
   generatePlannedTasks,
   getSeedInventoryItemFromAppState,
   listSeedInventoryItemsFromAppState,
@@ -636,6 +637,49 @@ describe('planned task generation', () => {
   });
 });
 
+
+
+describe('operational task generation', () => {
+  it('generates deterministic batch-linked tasks from stage timelines using latest active cycle anchors', () => {
+    const fixture = goldenFixtures['../../../../fixtures/golden/trier-v1.json'] as Record<string, unknown>;
+
+    const withBatches = {
+      ...fixture,
+      batches: [
+        {
+          batchId: 'batch-alpha',
+          cropId: 'tomato',
+          startedAt: '2026-03-01T00:00:00Z',
+          stage: 'transplant',
+          stageEvents: [
+            { stage: 'pre_sown', occurredAt: '2026-03-01T00:00:00Z' },
+            { stage: 'germinated', occurredAt: '2026-03-10T00:00:00Z' },
+            { stage: 'transplant', occurredAt: '2026-05-01T00:00:00Z' },
+            { stage: 'transplant', occurredAt: '2026-05-15T00:00:00Z' },
+          ],
+          assignments: [{ bedId: 'bed_001', assignedAt: '2026-05-15T00:00:00Z' }],
+        },
+      ],
+    };
+
+    const first = generateOperationalTasks(withBatches);
+    const second = generateOperationalTasks(withBatches);
+
+    expect(first).toEqual(second);
+    expect(first).not.toHaveLength(0);
+    expect(first.every((task) => task.batchId === 'batch-alpha')).toBe(true);
+    expect(first.map((task) => task.sourceKey)).toEqual([...first.map((task) => task.sourceKey)].sort());
+
+    const hardenOffTasks = first.filter((task) => task.type === 'harden-off');
+    expect(hardenOffTasks).toHaveLength(2);
+    expect(hardenOffTasks.every((task) => task.sourceKey.includes('2026-05-15t00:00:00z'))).toBe(true);
+
+    const transplantAnchorTasks = first.filter((task) =>
+      ['harden-off', 'bed-assignment', 'harvest-reminder'].includes(task.type),
+    );
+    expect(transplantAnchorTasks.every((task) => task.sourceKey.includes('2026-05-15t00:00:00z'))).toBe(true);
+  });
+});
 describe('generated task upsert boundary helper', () => {
   it('preserves existing status while updating regenerated task fields', () => {
     const appStateWithTask = {


### PR DESCRIPTION
### Motivation
- Operational tasks should be derived from each batch's `stageEvents` timeline (germination, pot-up, harden-off, transplant anchors, harvest reminders) rather than only from static planning rules. 
- Generated operational tasks must be stable across regenerations by using a deterministic `sourceKey` built from `(batchId, taskType, anchorOccurredAt, stageEventIndex)`. 
- When multiple matching stage events exist (e.g., repeated `transplant`), use the latest active cycle as the anchor to avoid unstable duplicates.

### Description
- Added `generateOperationalTasks` to `frontend/src/data/repos/taskRepository.ts` which derives operational tasks per batch from stage timeline events and normalizes output ordering by date and `sourceKey`. 
- Implemented compact helpers in the same file: `toIsoDate`, `addDays`, `sortStageEvents`, `selectLatestStageEvent`, and `buildOperationalTaskSourceKey` to keep selection and key generation deterministic. 
- Exported `generateOperationalTasks` from `frontend/src/data/index.ts` so repository callers and tests can use it. 
- Added an automated test case to `frontend/src/data/validation/index.test.ts` that validates deterministic regeneration, batch linkage, sorted `sourceKey`s, and the latest-transplant anchor policy for harvest/harden-off/assignment tasks.

### Testing
- Added a Vitest case `operational task generation` in `frontend/src/data/validation/index.test.ts` that asserts the generator is deterministic, returns non-empty batch-linked tasks, produces sorted `sourceKey`s, and uses the latest transplant event as anchor. 
- The test suite was not executed as part of this patch and should be run locally or in CI (`pnpm --filter frontend test` / `vitest`) to validate behavior in the project environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5b93b70d08326b9049aa7abd64683)