### PR TITLE
Calendar: implement task list UI with filters, overdue toggle, and status actions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,18 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
 import { Link, Navigate, NavLink, Route, Routes, useParams, useSearchParams } from 'react-router-dom';
-import type { Batch, Bed } from './contracts';
+import type { Batch, Bed, Task } from './contracts';
 import {
   SchemaValidationError,
   initializeAppStateStorage,
   listBedsFromAppState,
   listBatchesFromAppState,
+  listTasksFromAppState,
   loadAppStateFromIndexedDb,
   loadPhotoBlobFromIndexedDb,
   resetToGoldenDataset,
   saveAppStateToIndexedDb,
   savePhotoBlobToIndexedDb,
+  upsertTaskInAppState,
   upsertBatchInAppState,
   upsertBedInAppState,
   getActiveBedAssignment,
@@ -591,7 +593,265 @@ function BedDetailPage() {
 }
 
 function CalendarPage() {
-  return <p>Calendar</p>;
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [bedNames, setBedNames] = useState<Record<string, string>>({});
+  const [cropNames, setCropNames] = useState<Record<string, string>>({});
+  const [isLoading, setIsLoading] = useState(true);
+  const [savingTaskId, setSavingTaskId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      const appState = await loadAppStateFromIndexedDb();
+
+      if (!appState) {
+        setTasks([]);
+        setBedNames({});
+        setCropNames({});
+        setIsLoading(false);
+        return;
+      }
+
+      setTasks(listTasksFromAppState(appState));
+      setBedNames(Object.fromEntries(appState.beds.map((bed) => [bed.bedId, bed.name])));
+      setCropNames(Object.fromEntries(appState.crops.map((crop) => [crop.cropId, crop.name])));
+      setIsLoading(false);
+    };
+
+    void load();
+  }, []);
+
+  const filters = {
+    days: searchParams.get('days') ?? '30',
+    bed: searchParams.get('bed') ?? '',
+    crop: searchParams.get('crop') ?? '',
+    status: searchParams.get('status') ?? '',
+    type: searchParams.get('type') ?? '',
+    overdue: searchParams.get('overdue') === '1',
+  };
+
+  const updateFilter = (name: string, value: string) => {
+    const next = new URLSearchParams(searchParams);
+
+    if (value) {
+      next.set(name, value);
+    } else {
+      next.delete(name);
+    }
+
+    setSearchParams(next, { replace: true });
+  };
+
+  const localToday = useMemo(() => {
+    const today = new Date();
+    const localOffsetMs = today.getTimezoneOffset() * 60_000;
+    return new Date(today.getTime() - localOffsetMs).toISOString().slice(0, 10);
+  }, []);
+
+  const rangeEnd = useMemo(() => {
+    const startDate = new Date(`${localToday}T00:00:00`);
+    startDate.setDate(startDate.getDate() + Number(filters.days));
+    const localOffsetMs = startDate.getTimezoneOffset() * 60_000;
+    return new Date(startDate.getTime() - localOffsetMs).toISOString().slice(0, 10);
+  }, [filters.days, localToday]);
+
+  const bedOptions = useMemo(
+    () =>
+      Array.from(new Set(tasks.map((task) => task.bedId).filter(Boolean)))
+        .sort((left, right) => (bedNames[left] ?? left).localeCompare(bedNames[right] ?? right))
+        .map((bedId) => ({ value: bedId, label: bedNames[bedId] ?? bedId })),
+    [bedNames, tasks],
+  );
+
+  const cropOptions = useMemo(
+    () =>
+      Array.from(new Set(tasks.map((task) => task.cropId).filter(Boolean)))
+        .sort((left, right) => (cropNames[left] ?? left).localeCompare(cropNames[right] ?? right))
+        .map((cropId) => ({ value: cropId, label: cropNames[cropId] ?? cropId })),
+    [cropNames, tasks],
+  );
+
+  const statusOptions = useMemo(
+    () => Array.from(new Set(tasks.map((task) => task.status).filter(Boolean))).sort(),
+    [tasks],
+  );
+
+  const typeOptions = useMemo(
+    () => Array.from(new Set(tasks.map((task) => task.type).filter(Boolean))).sort(),
+    [tasks],
+  );
+
+  const filteredTasks = useMemo(
+    () =>
+      tasks
+        .filter((task) => {
+          const inWindow = task.date >= localToday && task.date <= rangeEnd;
+          const isOverdue = task.date < localToday;
+
+          if (!inWindow && !(filters.overdue && isOverdue)) {
+            return false;
+          }
+
+          if (filters.bed && task.bedId !== filters.bed) {
+            return false;
+          }
+
+          if (filters.crop && task.cropId !== filters.crop) {
+            return false;
+          }
+
+          if (filters.status && task.status !== filters.status) {
+            return false;
+          }
+
+          if (filters.type && task.type !== filters.type) {
+            return false;
+          }
+
+          return true;
+        })
+        .sort((left, right) => {
+          if (left.date !== right.date) {
+            return left.date.localeCompare(right.date);
+          }
+
+          return left.id.localeCompare(right.id);
+        }),
+    [filters.bed, filters.crop, filters.overdue, filters.status, filters.type, localToday, rangeEnd, tasks],
+  );
+
+  const handleToggleTaskStatus = async (task: Task) => {
+    if (savingTaskId) {
+      return;
+    }
+
+    setSavingTaskId(task.id);
+
+    try {
+      const appState = await loadAppStateFromIndexedDb();
+      if (!appState) {
+        return;
+      }
+
+      const doneStatuses = new Set(['done', 'completed']);
+      const isDone = doneStatuses.has(task.status.toLowerCase());
+      const updatedTask = { ...task, status: isDone ? 'pending' : 'done' };
+      const nextState = upsertTaskInAppState(appState, updatedTask);
+      await saveAppStateToIndexedDb(nextState);
+      setTasks((current) => current.map((entry) => (entry.id === updatedTask.id ? updatedTask : entry)));
+    } finally {
+      setSavingTaskId(null);
+    }
+  };
+
+  return (
+    <section className="calendar-page">
+      <h2>Calendar</h2>
+      <div className="calendar-range-toggle" role="group" aria-label="Date window">
+        {[7, 30, 90].map((days) => (
+          <button
+            key={days}
+            type="button"
+            className={filters.days === String(days) ? 'active' : ''}
+            onClick={() => updateFilter('days', String(days))}
+          >
+            {days} days
+          </button>
+        ))}
+        <label>
+          <input
+            type="checkbox"
+            checked={filters.overdue}
+            onChange={(event) => updateFilter('overdue', event.target.checked ? '1' : '')}
+          />{' '}
+          Show past due
+        </label>
+      </div>
+
+      <div className="calendar-filters">
+        <label>
+          Bed
+          <select value={filters.bed} onChange={(event) => updateFilter('bed', event.target.value)}>
+            <option value="">All beds</option>
+            {bedOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Crop
+          <select value={filters.crop} onChange={(event) => updateFilter('crop', event.target.value)}>
+            <option value="">All crops</option>
+            {cropOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Status
+          <select value={filters.status} onChange={(event) => updateFilter('status', event.target.value)}>
+            <option value="">All statuses</option>
+            {statusOptions.map((status) => (
+              <option key={status} value={status}>
+                {status}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Task type
+          <select value={filters.type} onChange={(event) => updateFilter('type', event.target.value)}>
+            <option value="">All types</option>
+            {typeOptions.map((taskType) => (
+              <option key={taskType} value={taskType}>
+                {taskType}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {isLoading ? <p className="batch-empty-state">Loading tasks…</p> : null}
+
+      {!isLoading ? (
+        <ul className="task-list">
+          {filteredTasks.map((task) => {
+            const isDone = ['done', 'completed'].includes(task.status.toLowerCase());
+            const isOverdue = task.date < localToday && !isDone;
+
+            return (
+              <li key={task.id} className={`task-row${isOverdue ? ' is-overdue' : ''}`}>
+                <div className="task-row-main">
+                  <p className="task-row-date">{task.date}</p>
+                  <div className="task-row-badges">
+                    <span className="task-type-badge">{task.type.replace(/[-_]/g, ' ')}</span>
+                    <span className={`task-status-badge${isDone ? ' is-done' : ''}`}>{task.status}</span>
+                  </div>
+                  <p className="task-row-meta">
+                    Bed: {(bedNames[task.bedId] ?? task.bedId) || '—'} · Crop: {(cropNames[task.cropId] ?? task.cropId) || '—'}
+                  </p>
+                  {task.batchId ? (
+                    <p className="task-row-meta">
+                      Batch: <Link to={`/batches/${task.batchId}`}>{task.batchId}</Link>
+                    </p>
+                  ) : null}
+                </div>
+                <button type="button" onClick={() => void handleToggleTaskStatus(task)} disabled={savingTaskId === task.id}>
+                  {isDone ? 'Mark undone' : 'Mark done'}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+
+      {!isLoading && filteredTasks.length === 0 ? <p className="batch-empty-state">No tasks in this range.</p> : null}
+    </section>
+  );
 }
 
 const getDerivedBedId = (batch: Batch): string | null => getActiveBedAssignment(batch, new Date().toISOString())?.bedId ?? null;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -169,6 +169,162 @@ body {
   text-align: left;
 }
 
+.calendar-page {
+  width: min(900px, 100%);
+  margin: 0 auto;
+  display: grid;
+  gap: 1rem;
+  text-align: left;
+}
+
+.calendar-page h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.calendar-range-toggle {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.calendar-range-toggle button {
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  background: #ffffff;
+  font: inherit;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.calendar-range-toggle button.active {
+  background: #eef2ff;
+  border-color: #c7d2fe;
+  color: #3730a3;
+  font-weight: 700;
+}
+
+.calendar-range-toggle label {
+  font-size: 0.85rem;
+  color: #374151;
+}
+
+.calendar-filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.6rem;
+}
+
+.calendar-filters label {
+  display: grid;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  color: #374151;
+}
+
+.calendar-filters select {
+  border: 1px solid #d1d5db;
+  border-radius: 0.45rem;
+  padding: 0.45rem 0.55rem;
+  font: inherit;
+  background: #ffffff;
+}
+
+.task-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.task-row {
+  border: 1px solid #e5e7eb;
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  background: #ffffff;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.task-row.is-overdue {
+  border-color: #fecaca;
+  background: #fff7f7;
+}
+
+.task-row button {
+  border: 1px solid #d1d5db;
+  border-radius: 0.45rem;
+  background: #ffffff;
+  color: #111827;
+  padding: 0.4rem 0.65rem;
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.task-row-main {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.task-row-date {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #374151;
+  font-weight: 600;
+}
+
+.task-row-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.task-type-badge,
+.task-status-badge {
+  font-size: 0.72rem;
+  border-radius: 999px;
+  padding: 0.2rem 0.5rem;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.task-type-badge {
+  background: #ecfeff;
+  color: #0e7490;
+  border: 1px solid #a5f3fc;
+}
+
+.task-status-badge {
+  background: #fef3c7;
+  color: #92400e;
+  border: 1px solid #fcd34d;
+}
+
+.task-status-badge.is-done {
+  background: #dcfce7;
+  color: #166534;
+  border-color: #86efac;
+}
+
+.task-row-meta {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #4b5563;
+}
+
+.task-row-meta a {
+  color: #1d4ed8;
+  text-decoration: none;
+  font-weight: 600;
+}
+
 .batches-page h2 {
   margin: 0;
   font-size: 1.2rem;


### PR DESCRIPTION
### Motivation
- Provide a practical day/week view so users can see actionable tasks (default next 30 days) with quick toggles for 7/30/90 windows and a "Show past due" option.
- Allow fast client-side filtering by bed, crop, status, and task type and surface batch navigation from task rows.
- Enable quick mark-done/mark-undone actions that persist using existing app-state helpers without changing domain logic.

### Description
- Replaced the placeholder `CalendarPage` with a task-list implementation inside `frontend/src/App.tsx` that loads tasks via `listTasksFromAppState` and resolves bed/crop labels from app state.
- Added query-param-driven filters and range toggles using `useSearchParams`, including `days` and `overdue`, and wired a per-row `Mark done`/`Mark undone` action that persists via `upsertTaskInAppState` and `saveAppStateToIndexedDb`.
- Rendered task rows showing date, task-type and status badges, bed/crop labels, and batch links that navigate to `/batches/:batchId` when present.
- Added presentation styles for the calendar UI in `frontend/src/index.css` and added necessary imports/types (`Task`, `listTasksFromAppState`, `upsertTaskInAppState`) to `App.tsx`.

### Testing
- Attempted an automated Playwright script to capture `http://127.0.0.1:5173/calendar`, but it failed with `ERR_EMPTY_RESPONSE` because the local dev server was not running in this environment.
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6e2b3a9f88326a3d4f04f8f541653)