### PR TITLE
Nutrition tab: card-based coverage UI, flags, and missing-data messaging

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
@@ -287,22 +287,24 @@ describe('App', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Coverage summary')).toBeInTheDocument();
+      expect(screen.getByText('Macro coverage')).toBeInTheDocument();
     });
 
     expect(
       screen.getByText((_, element) => {
         const text = element?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
-        return element?.tagName === 'LI' && text.includes('Calories') && text.includes('total 23100 kcal') && text.includes('per day 63 kcal');
+        return element?.tagName === 'LI' && text.includes('Calories') && text.includes('total 23100 kcal') && text.includes('per day 63 kcal') && text.includes('coverage vs generic target: 3%');
       }),
     ).toBeInTheDocument();
     expect(
       screen.getByText((_, element) => {
         const text = element?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
-        return element?.tagName === 'LI' && text.includes('Protein') && text.includes('total 600 g') && text.includes('per day 1.64 g');
+        return element?.tagName === 'LI' && text.includes('Protein') && text.includes('total 600 g') && text.includes('per day 1.64 g') && text.includes('coverage vs generic target: 3%');
       }),
     ).toBeInTheDocument();
-    expect(screen.getByText('Insufficient yield data: none.')).toBeInTheDocument();
+    expect(screen.getByText('Missing-data warning: none.')).toBeInTheDocument();
+    expect(screen.getByText('Key micronutrients')).toBeInTheDocument();
+    expect(screen.getByText(/coverage labels use generic targets/i)).toBeInTheDocument();
   });
 
   it('flags plans with insufficient yield data in nutrition assumptions', async () => {
@@ -339,7 +341,7 @@ describe('App', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Insufficient yield data')).toBeInTheDocument();
+      expect(screen.getByText('Missing-data warning')).toBeInTheDocument();
     });
 
     expect(screen.getByText('crop_unknown')).toBeInTheDocument();
@@ -374,7 +376,8 @@ describe('App', () => {
       expect(screen.getByText('Vegan nutrition flags')).toBeInTheDocument();
     });
 
-    const flags = screen.getAllByRole('listitem').filter((item) => item.textContent?.includes('planning check') || item.textContent?.includes('B12 coverage gap'));
+    const flagsSection = screen.getByText('Vegan nutrition flags').closest('article');
+    const flags = within(flagsSection as HTMLElement).getAllByRole('listitem');
     expect(flags).toHaveLength(3);
     expect(flags[0]).toHaveTextContent('Vitamin B12 coverage gap');
     expect(flags[1]).toHaveTextContent('Iodine planning check');

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2205,6 +2205,11 @@ type NutritionMetric = {
   unit: 'kcal' | 'g' | 'mg' | 'mcg' | 'IU';
 };
 
+type NutritionTarget = {
+  daily: number;
+  label: string;
+};
+
 type NutritionSummary = {
   totals: Record<string, number>;
   excludedCrops: string[];
@@ -2249,6 +2254,15 @@ const NUTRITION_FLAGS: NutritionFlag[] = [
     guidanceText: 'Informational only: consider ALA-focused foods such as flax, chia, and walnuts in rotation plans.',
   },
 ];
+
+const NUTRITION_TARGETS: Record<string, NutritionTarget> = {
+  kcal: { daily: 2000, label: 'Generic target 2000 kcal/day' },
+  protein: { daily: 50, label: 'Generic target 50 g/day' },
+  fat: { daily: 70, label: 'Generic target 70 g/day' },
+  vitamin_c: { daily: 90, label: 'Generic target 90 mg/day' },
+  vitamin_a: { daily: 900, label: 'Generic target 900 mcg/day' },
+  vitamin_k: { daily: 120, label: 'Generic target 120 mcg/day' },
+};
 
 const toYieldGrams = (plan: CropPlan): number | null => {
   if (!plan.expectedYield || !Number.isFinite(plan.expectedYield.amount) || plan.expectedYield.amount <= 0) {
@@ -2337,11 +2351,13 @@ function NutritionPage() {
 
   const summary = useMemo(() => summarizeNutrition(cropPlans, crops), [cropPlans, crops]);
   const safeDays = Number.isFinite(days) && days > 0 ? days : 365;
+  const macroMetrics = NUTRITION_METRICS.filter((metric) => ['kcal', 'protein', 'fat'].includes(metric.key));
+  const microMetrics = NUTRITION_METRICS.filter((metric) => ['vitamin_c', 'vitamin_a', 'vitamin_k'].includes(metric.key));
 
   return (
     <section className="data-page">
       <h2>Nutrition</h2>
-      <p>Rough coverage estimate using planned yield and crop nutrition profiles.</p>
+      <p>Rough coverage estimate using planned yield and crop nutrition profiles. Generic targets only; not personalized advice.</p>
       <label>
         Horizon (days)
         <input
@@ -2354,62 +2370,107 @@ function NutritionPage() {
       </label>
       {isLoading ? <p>Loading nutrition data…</p> : null}
       {!isLoading ? (
-        <>
-          <h3>Vegan nutrition flags</h3>
-          <p>Informational only, not medical advice.</p>
-          <ul>
-            {summary.flags.map((flag) => (
-              <li key={flag.title}>
-                <strong>{flag.title}</strong> ({flag.severity}): {flag.rationale} {flag.guidanceText}
-              </li>
-            ))}
-          </ul>
+        <div className="nutrition-layout">
+          <article className="nutrition-card">
+            <h3>Macro coverage</h3>
+            <p className="nutrition-card-note">Totals and per-day estimates from the selected horizon.</p>
+            <ul className="nutrition-metric-list">
+              {macroMetrics.map((metric) => {
+                const total = roundMetricValue(summary.totals[metric.key] ?? 0, metric.unit);
+                const perDay = roundMetricValue(total / safeDays, metric.unit);
+                const target = NUTRITION_TARGETS[metric.key];
+                const coverage = target ? Math.round((perDay / target.daily) * 100) : 0;
 
-          <h3>Coverage summary</h3>
-          <ul>
-            {NUTRITION_METRICS.map((metric) => {
-              const total = roundMetricValue(summary.totals[metric.key] ?? 0, metric.unit);
-              const perDay = roundMetricValue(total / safeDays, metric.unit);
+                return (
+                  <li key={metric.key} className="nutrition-metric-item">
+                    <p>
+                      <strong>{metric.label}</strong>
+                    </p>
+                    <p>
+                      total {total} {metric.unit} · per day {perDay} {metric.unit}
+                    </p>
+                    <p>
+                      coverage vs generic target: {coverage}% ({target?.label})
+                    </p>
+                  </li>
+                );
+              })}
+            </ul>
+          </article>
 
-              return (
-                <li key={metric.key}>
-                  <strong>{metric.label}</strong>: total {total} {metric.unit} · per day {perDay} {metric.unit}
+          <article className="nutrition-card">
+            <h3>Key micronutrients</h3>
+            <p className="nutrition-card-note">Coverage labels use generic targets and are informational only.</p>
+            <ul className="nutrition-metric-list">
+              {microMetrics.map((metric) => {
+                const total = roundMetricValue(summary.totals[metric.key] ?? 0, metric.unit);
+                const perDay = roundMetricValue(total / safeDays, metric.unit);
+                const target = NUTRITION_TARGETS[metric.key];
+                const coverage = target ? Math.round((perDay / target.daily) * 100) : 0;
+
+                return (
+                  <li key={metric.key} className="nutrition-metric-item">
+                    <p>
+                      <strong>{metric.label}</strong>
+                    </p>
+                    <p>
+                      total {total} {metric.unit} · per day {perDay} {metric.unit}
+                    </p>
+                    <p>
+                      coverage vs generic target: {coverage}% ({target?.label})
+                    </p>
+                  </li>
+                );
+              })}
+            </ul>
+          </article>
+
+          <article className="nutrition-card">
+            <h3>Vegan nutrition flags</h3>
+            <p className="nutrition-card-note">Informational only, not medical advice.</p>
+            <ul className="nutrition-flag-list">
+              {summary.flags.map((flag) => (
+                <li key={flag.title} className={`nutrition-flag-item nutrition-flag-${flag.severity}`}>
+                  <strong>{flag.title}</strong> ({flag.severity}): {flag.rationale} {flag.guidanceText}
                 </li>
-              );
-            })}
-          </ul>
+              ))}
+            </ul>
+          </article>
 
-          <h3>Assumptions and confidence</h3>
-          <ul>
-            <li>Uses expectedYield from CropPlan and nutritionProfile values from each crop.</li>
-            <li>Per 100g entries are normalized by mass yield (kg/g).</li>
-            <li>Per serving entries require piece-based yield; otherwise crop is flagged below.</li>
-            <li>Rounding: kcal rounded to whole numbers, other nutrients rounded to 2 decimals.</li>
-          </ul>
-          {summary.excludedCrops.length > 0 ? (
-            <>
-              <h4>Insufficient yield data</h4>
-              <ul>
+          <article className="nutrition-card">
+            <h3>Assumptions and missing data</h3>
+            <ul className="nutrition-assumption-list">
+              <li>Generic targets are used for coverage labels (not individualized).</li>
+              <li>Uses expectedYield from CropPlan and nutritionProfile values from each crop.</li>
+              <li>Per 100g entries are normalized by mass yield (kg/g).</li>
+              <li>Per serving entries require piece-based yield; otherwise crop is listed below.</li>
+              <li>Rounding: kcal rounded to whole numbers, other nutrients rounded to 2 decimals.</li>
+            </ul>
+            <h4>Missing-data warning</h4>
+            {summary.excludedCrops.length > 0 ? (
+              <ul className="nutrition-warning-list">
                 {summary.excludedCrops.map((name) => (
                   <li key={name}>{name}</li>
                 ))}
               </ul>
-            </>
-          ) : (
-            <p>Insufficient yield data: none.</p>
-          )}
+            ) : (
+              <p className="nutrition-card-note">Missing-data warning: none.</p>
+            )}
+          </article>
 
-          <h4>Confidence notes</h4>
-          {summary.confidenceNotes.length === 0 ? (
-            <p>No confidence notes available.</p>
-          ) : (
-            <ul>
-              {summary.confidenceNotes.map((note) => (
-                <li key={note}>{note}</li>
-              ))}
-            </ul>
-          )}
-        </>
+          <article className="nutrition-card">
+            <h4>Confidence notes</h4>
+            {summary.confidenceNotes.length === 0 ? (
+              <p className="nutrition-card-note">No confidence notes available.</p>
+            ) : (
+              <ul className="nutrition-assumption-list">
+                {summary.confidenceNotes.map((note) => (
+                  <li key={note}>{note}</li>
+                ))}
+              </ul>
+            )}
+          </article>
+        </div>
       ) : null}
     </section>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -832,6 +832,108 @@ body {
   padding: 0.4rem 0.5rem;
 }
 
+.data-page {
+  width: min(900px, 100%);
+  margin: 0 auto;
+  display: grid;
+  gap: 0.9rem;
+  text-align: left;
+}
+
+.data-page h2,
+.data-page h3,
+.data-page h4 {
+  margin: 0;
+}
+
+.data-page label {
+  display: grid;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  color: #374151;
+}
+
+.data-page input {
+  border: 1px solid #d1d5db;
+  border-radius: 0.45rem;
+  padding: 0.45rem 0.55rem;
+  background: #ffffff;
+  font: inherit;
+}
+
+.nutrition-layout {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.nutrition-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 0.8rem;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.nutrition-card-note {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #4b5563;
+  overflow-wrap: anywhere;
+}
+
+.nutrition-metric-list,
+.nutrition-flag-list,
+.nutrition-assumption-list,
+.nutrition-warning-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.nutrition-metric-item,
+.nutrition-flag-item {
+  border: 1px solid #e5e7eb;
+  border-radius: 0.6rem;
+  padding: 0.55rem;
+  display: grid;
+  gap: 0.3rem;
+  background: #f9fafb;
+}
+
+.nutrition-metric-item p,
+.nutrition-flag-item {
+  margin: 0;
+  font-size: 0.82rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.nutrition-assumption-list li,
+.nutrition-warning-list li {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #374151;
+  overflow-wrap: anywhere;
+}
+
+.nutrition-flag-high {
+  border-color: #fecaca;
+  background: #fff7f7;
+}
+
+.nutrition-flag-medium {
+  border-color: #fde68a;
+  background: #fffbeb;
+}
+
+.nutrition-flag-info {
+  border-color: #bfdbfe;
+  background: #eff6ff;
+}
+
 .seed-inventory-page {
   width: min(900px, 100%);
   margin: 0 auto;


### PR DESCRIPTION
### Motivation
- Improve the Nutrition screen presentation for mobile-first readability by replacing dense list/table output with stacked, card-like UI blocks. 
- Surface vegan nutrition flags (B12, iodine, omega-3) clearly with non-prescriptive language and rationale. 
- Show simple % coverage versus generic daily targets so users get a quick sense of macro/micronutrient coverage without changing existing domain calculations.

### Description
- Reworked the Nutrition view in `frontend/src/App.tsx` to render stacked `article` cards for Macro coverage, Key micronutrients, Vegan nutrition flags, Assumptions & missing-data, and Confidence notes, while preserving existing aggregation logic in `summarizeNutrition` and `toYieldGrams`.
- Added `NUTRITION_TARGETS` and per-day `% coverage vs generic target` labels for selected metrics (calories, protein, fat and key micros) and localized the macro/micro split via `macroMetrics` / `microMetrics` selectors.
- Introduced compact, mobile-first styles in `frontend/src/index.css` (`.nutrition-card`, `.nutrition-layout`, metric/flag list styles, and severity-based flag styles) to keep copy wrapped and readable.
- Updated UI tests in `frontend/src/App.test.tsx` to assert the new headings/content and to scope flag assertions to the Vegan flags card using `within(...)` rather than global list-item scanning.

### Testing
- Unit tests were updated: `frontend/src/App.test.tsx` was modified to expect the new headings and content structure (macro coverage, key micronutrients, missing-data wording, and scoped flag assertions). 
- No automated test runner was executed during this rollout; please run the project test suite (for example `yarn test` or `npm test`) locally or in CI to validate the updated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a7c4a5888326991a6e46a6b62673)