### PR TITLE
Add app-level recovery mode with ErrorBoundary and recovery UI

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import '@testing-library/jest-dom/vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
-import App from './App';
+import App, { RecoveryScreen } from './App';
 import {
   initializeAppStateStorage,
   loadAppStateFromIndexedDb,
@@ -72,6 +72,48 @@ describe('App', () => {
     cleanup();
     vi.unstubAllEnvs();
     vi.clearAllMocks();
+  });
+
+
+  it('renders recovery mode and requires explicit reset confirmation', async () => {
+    render(<RecoveryScreen error={new Error('corrupt state')} onRetry={vi.fn()} />);
+
+    expect(screen.getByRole('heading', { name: 'Recovery mode' })).toBeInTheDocument();
+    const resetButton = screen.getByRole('button', { name: 'Reset local database' });
+    expect(resetButton).toBeDisabled();
+
+    fireEvent.click(resetButton);
+    expect(resetToGoldenDataset).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /I understand reset will replace local data/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Reset local database' }));
+
+    await waitFor(() => {
+      expect(resetToGoldenDataset).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('exports readable data from recovery mode', async () => {
+    vi.mocked(loadAppStateFromIndexedDb).mockResolvedValue({ schemaVersion: 1, beds: [], crops: [], cropPlans: [], batches: [], seedInventory: [], tasks: [] } as never);
+    render(<RecoveryScreen error={new Error('boom')} onRetry={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export readable data' }));
+
+    await waitFor(() => {
+      expect(serializeAppStateForExport).toHaveBeenCalledTimes(1);
+      expect(screen.getByText(/Export complete:/)).toBeInTheDocument();
+    });
+  });
+
+
+  it('calls retry from recovery mode without auto-looping actions', () => {
+    const onRetry = vi.fn();
+    render(<RecoveryScreen error={new Error('fail')} onRetry={onRetry} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(resetToGoldenDataset).not.toHaveBeenCalled();
   });
 
   it('renders the app title and primary navigation', () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2520,6 +2520,151 @@ type DataPageProps = {
   onResetToGoldenDataset: () => void;
 };
 
+type RecoveryScreenProps = {
+  error: unknown;
+  onRetry: () => void;
+};
+
+export function RecoveryScreen({ error, onRetry }: RecoveryScreenProps) {
+  const [isExporting, setIsExporting] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const [isResetting, setIsResetting] = useState(false);
+  const [exportMessage, setExportMessage] = useState<string | null>(null);
+  const [importMessage, setImportMessage] = useState<string | null>(null);
+  const [resetMessage, setResetMessage] = useState<string | null>(null);
+  const [pendingImportState, setPendingImportState] = useState<unknown | null>(null);
+  const [confirmReset, setConfirmReset] = useState(false);
+
+  const handleExportJson = useCallback(async () => {
+    if (isExporting) {
+      return;
+    }
+
+    setIsExporting(true);
+    setExportMessage(null);
+
+    try {
+      const appState = await loadAppStateFromIndexedDb();
+      if (!appState) {
+        setExportMessage('Export failed: no readable data was found in local storage.');
+        return;
+      }
+
+      const payload = serializeAppStateForExport(appState);
+      const timestamp = new Date().toISOString().replace(/[.:]/g, '-');
+      const fileName = `survival-garden-recovery-${timestamp}.json`;
+      const blob = new Blob([payload], { type: 'application/json' });
+      const objectUrl = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = objectUrl;
+      link.download = fileName;
+      link.click();
+      URL.revokeObjectURL(objectUrl);
+      setExportMessage(`Export complete: ${fileName}`);
+    } catch (exportError) {
+      setExportMessage(`Export failed: ${exportError instanceof Error ? exportError.message : 'Unknown error.'}`);
+    } finally {
+      setIsExporting(false);
+    }
+  }, [isExporting]);
+
+  const handleImportJson = useCallback(async (event: FormEvent<HTMLInputElement>) => {
+    const file = event.currentTarget.files?.[0];
+    event.currentTarget.value = '';
+
+    if (!file || isImporting) {
+      return;
+    }
+
+    setIsImporting(true);
+    setImportMessage(null);
+    setPendingImportState(null);
+
+    try {
+      const payload = await file.text();
+      const parsedState = parseImportedAppState(payload);
+      setPendingImportState(parsedState);
+      setImportMessage('Import file is valid. Replace existing data?');
+    } catch (importError) {
+      setImportMessage(`Import failed: ${importError instanceof Error ? importError.message : 'Unknown error.'}`);
+    } finally {
+      setIsImporting(false);
+    }
+  }, [isImporting]);
+
+  const handleConfirmImport = useCallback(async () => {
+    if (!pendingImportState || isImporting) {
+      return;
+    }
+
+    setIsImporting(true);
+    setImportMessage(null);
+
+    try {
+      await saveAppStateToIndexedDb(pendingImportState, { mode: 'replace' });
+      setPendingImportState(null);
+      setImportMessage('Import complete. Existing data was replaced.');
+    } catch (importError) {
+      setImportMessage(`Import failed while saving: ${importError instanceof Error ? importError.message : 'Unknown error.'}`);
+    } finally {
+      setIsImporting(false);
+    }
+  }, [isImporting, pendingImportState]);
+
+  const handleReset = useCallback(async () => {
+    if (!confirmReset || isResetting) {
+      return;
+    }
+
+    setIsResetting(true);
+    setResetMessage(null);
+
+    try {
+      await resetToGoldenDataset();
+      setResetMessage('Reset complete. You can retry loading the app now.');
+      setConfirmReset(false);
+    } catch (resetError) {
+      setResetMessage(`Reset failed: ${resetError instanceof Error ? resetError.message : 'Unknown error.'}`);
+    } finally {
+      setIsResetting(false);
+    }
+  }, [confirmReset, isResetting]);
+
+  return (
+    <div className="storage-error-screen" role="alert">
+      <h1>Recovery mode</h1>
+      <p>The app hit a runtime/storage error and stopped loading.</p>
+      <p>Nothing is deleted automatically. Choose a recovery action below.</p>
+      <p>{error instanceof Error ? `Error: ${error.message}` : 'Error: Unknown runtime failure.'}</p>
+      <div className="storage-error-actions">
+        <button type="button" onClick={onRetry}>Retry</button>
+        <button type="button" onClick={() => void handleExportJson()} disabled={isExporting}>
+          {isExporting ? 'Exporting…' : 'Export readable data'}
+        </button>
+      </div>
+      {exportMessage ? <p>{exportMessage}</p> : null}
+      <label>
+        Import backup JSON
+        <input type="file" accept="application/json,.json" onChange={(event) => void handleImportJson(event)} disabled={isImporting} />
+      </label>
+      {pendingImportState ? (
+        <button type="button" onClick={() => void handleConfirmImport()} disabled={isImporting}>
+          {isImporting ? 'Replacing data…' : 'Replace with imported backup'}
+        </button>
+      ) : null}
+      {importMessage ? <p>{importMessage}</p> : null}
+      <label>
+        <input type="checkbox" checked={confirmReset} onChange={(event) => setConfirmReset(event.currentTarget.checked)} disabled={isResetting} />
+        I understand reset will replace local data with the golden dataset.
+      </label>
+      <button type="button" onClick={() => void handleReset()} disabled={!confirmReset || isResetting}>
+        {isResetting ? 'Resetting…' : 'Reset local database'}
+      </button>
+      {resetMessage ? <p>{resetMessage}</p> : null}
+    </div>
+  );
+}
+
 function DataPage({ showDevResetButton, onResetToGoldenDataset }: DataPageProps) {
   const [isExporting, setIsExporting] = useState(false);
   const [exportMessage, setExportMessage] = useState<string | null>(null);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,47 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
-import App from './App';
+import App, { RecoveryScreen } from './App';
 import './index.css';
+
+type AppErrorBoundaryProps = {
+  children: React.ReactNode;
+};
+
+type AppErrorBoundaryState = {
+  error: unknown | null;
+  retryKey: number;
+};
+
+class AppErrorBoundary extends React.Component<AppErrorBoundaryProps, AppErrorBoundaryState> {
+  state: AppErrorBoundaryState = {
+    error: null,
+    retryKey: 0,
+  };
+
+  static getDerivedStateFromError(error: unknown): Pick<AppErrorBoundaryState, 'error'> {
+    return { error };
+  }
+
+  handleRetry = () => {
+    this.setState((current) => ({ error: null, retryKey: current.retryKey + 1 }));
+  };
+
+  render() {
+    if (this.state.error) {
+      return <RecoveryScreen error={this.state.error} onRetry={this.handleRetry} />;
+    }
+
+    return <React.Fragment key={this.state.retryKey}>{this.props.children}</React.Fragment>;
+  }
+}
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <AppErrorBoundary>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </AppErrorBoundary>
   </React.StrictMode>
 );


### PR DESCRIPTION
### Motivation
- Prevent the app from being silently bricked by runtime/indexedDB/schema failures by surfacing a recovery UX instead of blank/crash loops.
- Give users explicit, non-destructive actions (export readable data, import validated backup, reset with confirmation, and a manual retry) so recovery is deterministic and requires user consent.

### Description
- Wrap the root app in an `AppErrorBoundary` that catches render/runtime errors and exposes a controlled `retryKey` remount to avoid immediate crash loops (file: `frontend/src/main.tsx`).
- Add a `RecoveryScreen` component exported from `App.tsx` that displays the caught error and provides explicit actions only: `Retry`, `Export readable data` (reads via `loadAppStateFromIndexedDb` + `serializeAppStateForExport`), `Import backup JSON` (validated via `parseImportedAppState` before `saveAppStateToIndexedDb`), and `Reset local database` gated behind an explicit checkbox confirmation (uses `resetToGoldenDataset`) (file: `frontend/src/App.tsx`).
- Add focused unit tests to `App.test.tsx` covering the recovery UX: export flow from recovery mode, explicit reset confirmation gating, and that `Retry` calls back without auto-triggering other actions (file: `frontend/src/App.test.tsx`).
- Touched files: `frontend/src/main.tsx`, `frontend/src/App.tsx`, `frontend/src/App.test.tsx`.

### Testing
- Added unit tests to `frontend/src/App.test.tsx` for recovery behaviors (reset confirmation, export, retry); these tests were added to the repo but were not executed in this patch run.
- Attempted a browser screenshot via Playwright to validate the recovery screen, but the local dev server was not running and the attempt failed with `ERR_EMPTY_RESPONSE`.
- No CI/test runner was invoked as part of this fast patch; please run the test suite (`vitest`/`npm test` or project-specific test command) and a local dev server to validate the UI before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aadffa46e88326866f004bcf8ca316)