### PR TITLE
Canonicalize batch start timeline in schema and docs

### DIFF
--- a/docs/dotnet-readiness.md
+++ b/docs/dotnet-readiness.md
@@ -149,6 +149,40 @@ Example `GET /api/crop-plans?cropId=crop_potato&seasonYear=2026` response item:
 - `PUT /api/batches/{batchId}` body `Batch` -> `Batch`
 - `DELETE /api/batches/{batchId}` -> `204 No Content`
 
+Batch timeline canonicalization (vNext):
+
+- Canonical export does not include a separate required `start` object; start semantics are represented by `startedAt` + `stageEvents[0]`.
+- Mapping from legacy `start.*`:
+  - `start.date` -> `startedAt` and `stageEvents[0].occurredAt`
+  - `start.stage` -> `stageEvents[0].stage` and `currentStage` when no later stage events exist
+  - `start.location` -> `stageEvents[0].location` (or `stageEvents[0].meta.location` if needed for source fidelity)
+  - `start.method` -> `stageEvents[0].method` (or `stageEvents[0].meta.method` if needed for source fidelity)
+- `currentStage` should resolve to the latest stage event stage after mapping/import.
+- First-event guidance by propagation type:
+  - `seed`: prefer `sowing`/`seeding` when known; otherwise use a neutral initiation stage and preserve source stage text in `stageEvents[0].meta`.
+  - non-seed (`transplant`, `cutting`, `division`, `tuber`, `bulb`, `runner`, `graft`, `other`): prefer a propagation-appropriate first stage when known; otherwise use a neutral initiation stage and preserve source detail in `meta`.
+
+Minimal migration example (legacy start-only history -> valid timeline):
+
+```json
+{
+  "batchId": "batch_001",
+  "cropId": "crop_tomato",
+  "startedAt": "2026-03-01T00:00:00Z",
+  "currentStage": "sowing",
+  "stage": "sowing",
+  "stageEvents": [
+    {
+      "stage": "sowing",
+      "occurredAt": "2026-03-01T00:00:00Z",
+      "location": "greenhouse-bench-a",
+      "method": "direct-seed"
+    }
+  ],
+  "assignments": []
+}
+```
+
 ### App state + settings
 
 - `GET /api/app-state` -> `AppState | 404`

--- a/frontend/src/contracts/batch.schema.json
+++ b/frontend/src/contracts/batch.schema.json
@@ -25,7 +25,8 @@
       "maxLength": 120
     },
     "startedAt": {
-      "$ref": "#/$defs/isoDate"
+      "$ref": "#/$defs/isoDate",
+      "description": "Canonical start anchor. Must match stageEvents[0].occurredAt."
     },
     "propagationType": {
       "$ref": "#/$defs/propagationType"
@@ -33,12 +34,14 @@
     "startMethod": {
       "type": "string",
       "minLength": 1,
-      "maxLength": 80
+      "maxLength": 80,
+      "description": "Optional batch-level default for start method. When present, exporters should also set stageEvents[0].method."
     },
     "startLocation": {
       "type": "string",
       "minLength": 1,
-      "maxLength": 120
+      "maxLength": 120,
+      "description": "Optional batch-level default for start location. When present, exporters should also set stageEvents[0].location."
     },
     "startQuantity": {
       "$ref": "#/$defs/startQuantity"
@@ -64,10 +67,13 @@
     "currentStage": {
       "type": "string",
       "minLength": 1,
-      "maxLength": 80
+      "maxLength": 80,
+      "description": "Canonical current stage. Derived from the latest stage event during migration/import when omitted."
     },
     "stageEvents": {
       "type": "array",
+      "minItems": 1,
+      "description": "Canonical timeline. The first event represents batch start and should align with startedAt.",
       "items": {
         "$ref": "#/$defs/stageEvent"
       }


### PR DESCRIPTION
### Motivation
- Remove ambiguity between separate `start` semantics and the stage timeline by defining a single canonical model anchored by `startedAt` plus the first `stageEvents` entry.
- Provide explicit, propagation-aware mapping rules for legacy `start.*` fields to ensure deterministic migration behavior for seed and non-seed batches.
- Ensure minimal valid exports for historical data that only recorded start information by documenting a clear minimal migration example.

### Description
- Updated `frontend/src/contracts/batch.schema.json` to add descriptions clarifying that `startedAt` is the canonical start anchor, that `startMethod`/`startLocation` are batch-level defaults mapping into the first stage event, and that `currentStage` is derived from the latest stage event when omitted.
- Added `minItems: 1` and a descriptive comment to the `stageEvents` array so the first event is required and represents batch start.
- Expanded `docs/dotnet-readiness.md` under the Batches section with canonicalization rules, explicit mappings from legacy `start.*` into `startedAt`/`stageEvents[0]`, propagation-type first-event guidance, and a minimal migration example illustrating a start-only history transformation.

### Testing
- Ran a repository keyword search with `rg` for `start`, `stageEvents`, `startedAt`, `currentStage`, `startMethod`, and `startLocation` to confirm the schema and docs reflect the new guidance, and the search returned the updated locations successfully.
- Inspected updated files (`frontend/src/contracts/batch.schema.json` and `docs/dotnet-readiness.md`) to verify the new `description` fields and `minItems` insertion are present and correctly formatted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae8e05116c83268b2390a6b314eed3)