### PR TITLE
Add confidence metadata to batch contract and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ Photo/blob payload data is intentionally excluded from roundtrip guarantees. If 
 - `propagationType: "seed" | "transplant" | "cutting" | "division" | "tuber" | "bulb" | "runner" | "graft" | "other"`
 - `startQuantity: { count: number; unit: string }`
 - `currentStage: string`
-- `stageEvents: Array<{ stage; occurredAt; location?; method?; meta? }>`
+- `stageEvents: Array<{ stage; occurredAt; location?; method?; meta?: { confidence?: "exact" | "estimated" | "unknown"; ... } }>`
 - `bedAssignments: Array<{ bedId; assignedAt; removedAt?; meta? }>`
 - `photos: Array<{ id; storageRef; ...metadata }>`
 - Optional seed-specific counts: `seedCountPlanned?`, `seedCountGerminated?`
 - Optional universal count: `plantCountAlive?`
+- Confidence metadata can be attached at `batch.meta.confidence` and `stageEvents[i].meta.confidence` to annotate certainty of recorded facts (`exact`, `estimated`, `unknown`) without replacing the underlying value.
 
 Migration mapping guidance:
 - `batch.stage` -> `batch.currentStage`

--- a/docs/dotnet-readiness.md
+++ b/docs/dotnet-readiness.md
@@ -158,6 +158,8 @@ Batch timeline canonicalization (vNext):
   - `start.location` -> `stageEvents[0].location` (or `stageEvents[0].meta.location` if needed for source fidelity)
   - `start.method` -> `stageEvents[0].method` (or `stageEvents[0].meta.method` if needed for source fidelity)
 - `currentStage` should resolve to the latest stage event stage after mapping/import.
+- Confidence metadata may annotate uncertainty without removing values: use `batch.meta.confidence` and/or `stageEvents[i].meta.confidence` with `exact`, `estimated`, or `unknown`.
+- When propagation classification or first-stage mapping is inferred during migration, tag the inferred fact as `estimated` in the corresponding `meta.confidence` field.
 - First-event guidance by propagation type:
   - `seed`: prefer `sowing`/`seeding` when known; otherwise use a neutral initiation stage and preserve source stage text in `stageEvents[0].meta`.
   - non-seed (`transplant`, `cutting`, `division`, `tuber`, `bulb`, `runner`, `graft`, `other`): prefer a propagation-appropriate first stage when known; otherwise use a neutral initiation stage and preserve source detail in `meta`.

--- a/frontend/src/contracts/batch.schema.json
+++ b/frontend/src/contracts/batch.schema.json
@@ -116,11 +116,28 @@
       }
     },
     "meta": {
-      "type": "object",
-      "additionalProperties": true
+      "$ref": "#/$defs/metaWithConfidence"
     }
   },
   "$defs": {
+    "confidence": {
+      "type": "string",
+      "enum": [
+        "exact",
+        "estimated",
+        "unknown"
+      ],
+      "description": "Confidence annotation for a fact value. Use exact for source-backed values, estimated for inferred/approximate values, and unknown when confidence cannot be determined."
+    },
+    "metaWithConfidence": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "confidence": {
+          "$ref": "#/$defs/confidence"
+        }
+      }
+    },
     "id": {
       "type": "string",
       "minLength": 1,
@@ -203,8 +220,7 @@
           "maxLength": 80
         },
         "meta": {
-          "type": "object",
-          "additionalProperties": true
+          "$ref": "#/$defs/metaWithConfidence"
         }
       }
     },

--- a/frontend/src/generated/contracts.ts
+++ b/frontend/src/generated/contracts.ts
@@ -4,12 +4,15 @@
  */
 
 
+export type BatchConfidence = 'exact' | 'estimated' | 'unknown';
+
 export interface BatchStageEvent {
   stage: string;
   occurredAt: string;
   location?: string;
   method?: string;
   meta?: {
+    confidence?: BatchConfidence;
     [k: string]: unknown;
   };
 }
@@ -71,6 +74,7 @@ export interface Batch {
   notes?: string;
   photos?: BatchPhotoMetadata[] | unknown[] | undefined;
   meta?: {
+    confidence?: BatchConfidence;
     [k: string]: unknown;
   };
 }


### PR DESCRIPTION
### Motivation
- Preserve and surface uncertainty in batch timeline and metadata by annotating facts with an explicit confidence value (`exact` | `estimated` | `unknown`).
- Enable importer/migration guidance to mark inferred/approximate dates or classifications without changing core values or flows.

### Description
- Added a reusable `confidence` enum and `metaWithConfidence` `$defs` to `frontend/src/contracts/batch.schema.json` and replaced the canonical `meta` references with `metaWithConfidence` for `batch.meta` and `stageEvents[].meta`.
- Updated generated TypeScript contracts in `frontend/src/generated/contracts.ts` to include `export type BatchConfidence = 'exact' | 'estimated' | 'unknown'` and optional `confidence?: BatchConfidence` in `Batch.meta` and `BatchStageEvent.meta`.
- Documented semantics and migration guidance in `README.md` and `docs/dotnet-readiness.md` to recommend using `batch.meta.confidence` and `stageEvents[i].meta.confidence` and to mark inferred mappings as `estimated`.
- Kept changes presentation-only and did not alter domain logic, persistence, scoring, or canonical data shapes beyond optional metadata.

### Testing
- Attempted to regenerate types with `pnpm --filter frontend gen:types`, which failed due to missing frontend dependencies (`node_modules`) and `json-schema-to-typescript`, so `frontend/src/generated/contracts.ts` was updated manually to reflect the schema change; the generation step failed in this environment.
- No schema or unit test suites were executed in this environment after the change due to missing dependencies; commit includes the schema and generated-type edits so CI or local dev can run `pnpm install` and `pnpm --filter frontend gen:types` and existing test suites locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b16fcb5d288326a4de52e0c7630f9c)