### PR TITLE
docs: publish vNext import/export contract guide and canonical payload samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@
 
 `frontend/src/contracts/app-state.schema.json` defines the import/export `AppState` envelope and requires a numeric `schemaVersion` (integer, minimum `1`) for migration gating between persisted schema revisions.
 
+
+## Import/export contract docs & canonical payload samples
+
+For vNext contract details and migration mappings, see `docs/contracts/import-export-vnext.md`.
+
+Canonical sample payloads live in `docs/contracts/samples/`:
+- `crop.canonical.json`
+- `batch.seed.canonical.json`
+- `batch.regrow-runner.canonical.json`
+- `batch.tuber.canonical.json`
+- `task.canonical.json`
+- `app-state.canonical.json`
+
 ## Identifier & key strategy
 
 - Use UUID v4 IDs (`crypto.randomUUID`) for user-authored entities created at runtime.

--- a/docs/contracts/import-export-vnext.md
+++ b/docs/contracts/import-export-vnext.md
@@ -1,0 +1,160 @@
+# Import/Export Contract (vNext)
+
+This document defines the canonical import/export contract for vNext and provides migration mappings from accepted legacy payload variants.
+
+## Source of truth
+
+- `frontend/src/contracts/app-state.schema.json`
+- `frontend/src/contracts/crop.schema.json`
+- `frontend/src/contracts/batch.schema.json`
+- `frontend/src/contracts/task.schema.json`
+
+Canonical samples:
+
+- `docs/contracts/samples/crop.canonical.json`
+- `docs/contracts/samples/batch.seed.canonical.json`
+- `docs/contracts/samples/batch.regrow-runner.canonical.json`
+- `docs/contracts/samples/batch.tuber.canonical.json`
+- `docs/contracts/samples/task.canonical.json`
+- `docs/contracts/samples/app-state.canonical.json`
+
+## Canonical vs accepted legacy input
+
+- **Canonical export shape** is what contributors/backends should produce for new integrations.
+- **Accepted legacy input** is tolerated for migration, mostly through schema aliases on Batch/Crop fields.
+- Exporters should not emit legacy aliases when writing vNext payloads.
+
+## vNext schema evolution notes
+
+- Canonical vNext payloads use `AppState.schemaVersion = 2`.
+- Crop now supports richer metadata (`scientificName`, `taxonomy`, `aliases`, `isUserDefined`).
+- Batch modeling shifts from implicit nested legacy structures to explicit event/quantity fields:
+  - timeline in `stageEvents`
+  - placement in `bedAssignments`
+  - current state in `currentStage`
+  - start amount in `startQuantity`
+- Legacy aliases still exist in schema where needed for migration input:
+  - `batch.stage` (legacy alias)
+  - `batch.assignments` (legacy alias)
+  - `batch.id` (alias of `batchId`)
+  - `crop.id` (alias of `cropId`)
+  - `crop.commonName` (alias of `name`)
+
+## Migration mapping examples (before/after)
+
+### 1) Batch stage + assignment aliasing
+
+Before (legacy accepted):
+
+```json
+{
+  "id": "batch_tomato_2026",
+  "cropId": "crop_tomato",
+  "startedAt": "2026-03-01T08:00:00Z",
+  "stage": "seedling",
+  "stageEvents": [
+    {
+      "type": "sown",
+      "date": "2026-03-01T08:00:00Z"
+    }
+  ],
+  "assignments": [
+    {
+      "bedId": "bed_001",
+      "assignedAt": "2026-04-15T07:30:00Z"
+    }
+  ]
+}
+```
+
+After (canonical export):
+
+```json
+{
+  "batchId": "batch_tomato_2026",
+  "cropId": "crop_tomato",
+  "startedAt": "2026-03-01T08:00:00Z",
+  "currentStage": "seedling",
+  "stageEvents": [
+    {
+      "stage": "sown",
+      "occurredAt": "2026-03-01T08:00:00Z"
+    }
+  ],
+  "bedAssignments": [
+    {
+      "bedId": "bed_001",
+      "assignedAt": "2026-04-15T07:30:00Z"
+    }
+  ],
+  "stage": "seedling",
+  "assignments": [
+    {
+      "bedId": "bed_001",
+      "assignedAt": "2026-04-15T07:30:00Z"
+    }
+  ]
+}
+```
+
+Note: current schema still requires `stage` + `assignments`; include both canonical and alias fields until Issue 64/66 finalize the stricter export-only contract.
+
+### 2) Crop alias normalization
+
+Before (legacy accepted):
+
+```json
+{
+  "id": "crop_beans",
+  "commonName": "Pole Bean",
+  "createdAt": "2026-01-01T00:00:00Z",
+  "updatedAt": "2026-01-01T00:00:00Z"
+}
+```
+
+After (canonical export):
+
+```json
+{
+  "cropId": "crop_beans",
+  "name": "Pole Bean",
+  "createdAt": "2026-01-01T00:00:00Z",
+  "updatedAt": "2026-01-01T00:00:00Z"
+}
+```
+
+## Propagation modeling rules
+
+### When to use `startQuantity`
+
+Always populate `startQuantity` for batches when the initial amount is known.
+
+### When to use seed-specific counts
+
+Use only for seed propagation batches:
+
+- `seedCountPlanned`
+- `seedCountGerminated`
+
+### Universal count
+
+Use `plantCountAlive` for currently living plants regardless of propagation type.
+
+### Non-seed propagation
+
+For `runner`, `tuber`, `division`, `cutting`, etc.:
+
+- use `propagationType` + `startQuantity`
+- do not invent seed counts
+
+### Confidence metadata
+
+Use `meta.confidence` / `stageEvents[].meta.confidence` when the value quality matters:
+
+- `exact`
+- `estimated`
+- `unknown`
+
+## Minimal canonical payload set
+
+See the sample JSON files in `docs/contracts/samples/` for implementation-ready payloads.

--- a/docs/contracts/samples/app-state.canonical.json
+++ b/docs/contracts/samples/app-state.canonical.json
@@ -1,0 +1,131 @@
+{
+  "schemaVersion": 2,
+  "beds": [
+    {
+      "bedId": "bed_001",
+      "gardenId": "garden_home",
+      "name": "South Bed",
+      "createdAt": "2026-01-01T08:00:00Z",
+      "updatedAt": "2026-01-01T08:00:00Z"
+    }
+  ],
+  "crops": [
+    {
+      "cropId": "crop_tomato",
+      "name": "Tomato",
+      "scientificName": "Solanum lycopersicum",
+      "createdAt": "2026-01-10T09:00:00Z",
+      "updatedAt": "2026-02-01T09:00:00Z"
+    }
+  ],
+  "cropPlans": [
+    {
+      "planId": "plan_tomato_2026",
+      "cropId": "crop_tomato",
+      "bedId": "bed_001",
+      "seasonYear": 2026,
+      "plannedWindows": {
+        "sowing": [
+          {
+            "startMonth": 3,
+            "startWeek": 1,
+            "endMonth": 3,
+            "endWeek": 3
+          }
+        ],
+        "harvest": [
+          {
+            "startMonth": 7,
+            "startWeek": 1,
+            "endMonth": 9,
+            "endWeek": 4
+          }
+        ]
+      },
+      "expectedYield": {
+        "amount": 12,
+        "unit": "kg"
+      }
+    }
+  ],
+  "batches": [
+    {
+      "batchId": "batch_tomato_seed_2026",
+      "cropId": "crop_tomato",
+      "startedAt": "2026-03-01T08:00:00Z",
+      "propagationType": "seed",
+      "startQuantity": {
+        "count": 24,
+        "unit": "seeds"
+      },
+      "seedCountPlanned": 24,
+      "seedCountGerminated": 19,
+      "plantCountAlive": 18,
+      "stage": "seedling",
+      "currentStage": "seedling",
+      "stageEvents": [
+        {
+          "stage": "sown",
+          "occurredAt": "2026-03-01T08:00:00Z"
+        },
+        {
+          "stage": "seedling",
+          "occurredAt": "2026-03-18T08:00:00Z"
+        }
+      ],
+      "bedAssignments": [
+        {
+          "bedId": "bed_001",
+          "assignedAt": "2026-05-01T07:00:00Z"
+        }
+      ],
+      "assignments": [
+        {
+          "bedId": "bed_001",
+          "assignedAt": "2026-05-01T07:00:00Z"
+        }
+      ]
+    }
+  ],
+  "tasks": [
+    {
+      "id": "task_plant_tomato_2026_05_01",
+      "sourceKey": "batch_tomato_seed_2026|2026-05-01|crop_tomato|bed_001|transplant",
+      "date": "2026-05-01",
+      "type": "transplant",
+      "cropId": "crop_tomato",
+      "bedId": "bed_001",
+      "batchId": "batch_tomato_seed_2026",
+      "checklist": [
+        {
+          "label": "Harden off seedlings"
+        }
+      ],
+      "status": "open"
+    }
+  ],
+  "seedInventoryItems": [
+    {
+      "seedInventoryItemId": "seed_tomato_roma_001",
+      "cropId": "crop_tomato",
+      "variety": "Roma",
+      "quantity": 120,
+      "unit": "seeds",
+      "status": "available",
+      "createdAt": "2026-01-10T09:00:00Z",
+      "updatedAt": "2026-02-01T09:00:00Z"
+    }
+  ],
+  "settings": {
+    "settingsId": "settings_001",
+    "locale": "de-DE",
+    "timezone": "Europe/Berlin",
+    "weekStartsOn": "monday",
+    "units": {
+      "temperature": "celsius",
+      "yield": "metric"
+    },
+    "createdAt": "2026-01-01T00:00:00Z",
+    "updatedAt": "2026-01-01T00:00:00Z"
+  }
+}

--- a/docs/contracts/samples/batch.regrow-runner.canonical.json
+++ b/docs/contracts/samples/batch.regrow-runner.canonical.json
@@ -1,0 +1,32 @@
+{
+  "batchId": "batch_strawberry_runner_2026",
+  "cropId": "crop_strawberry",
+  "startedAt": "2026-06-10T10:30:00Z",
+  "propagationType": "runner",
+  "startQuantity": {
+    "count": 6,
+    "unit": "runner_plants"
+  },
+  "plantCountAlive": 6,
+  "stage": "rooting",
+  "currentStage": "rooting",
+  "stageEvents": [
+    {
+      "stage": "rooting",
+      "occurredAt": "2026-06-10T10:30:00Z",
+      "method": "pinned runner"
+    }
+  ],
+  "bedAssignments": [
+    {
+      "bedId": "bed_herb_patch",
+      "assignedAt": "2026-06-20T09:00:00Z"
+    }
+  ],
+  "assignments": [
+    {
+      "bedId": "bed_herb_patch",
+      "assignedAt": "2026-06-20T09:00:00Z"
+    }
+  ]
+}

--- a/docs/contracts/samples/batch.seed.canonical.json
+++ b/docs/contracts/samples/batch.seed.canonical.json
@@ -1,0 +1,52 @@
+{
+  "batchId": "batch_tomato_seed_2026",
+  "cropId": "crop_tomato",
+  "variety": "Roma",
+  "startedAt": "2026-03-01T08:00:00Z",
+  "propagationType": "seed",
+  "startMethod": "indoor tray",
+  "startLocation": "greenhouse bench A",
+  "startQuantity": {
+    "count": 24,
+    "unit": "seeds"
+  },
+  "seedCountPlanned": 24,
+  "seedCountGerminated": 19,
+  "plantCountAlive": 18,
+  "stage": "seedling",
+  "currentStage": "seedling",
+  "stageEvents": [
+    {
+      "stage": "sown",
+      "occurredAt": "2026-03-01T08:00:00Z",
+      "location": "greenhouse bench A",
+      "method": "indoor tray",
+      "meta": {
+        "confidence": "exact"
+      }
+    },
+    {
+      "stage": "seedling",
+      "occurredAt": "2026-03-18T08:00:00Z",
+      "meta": {
+        "confidence": "estimated"
+      }
+    }
+  ],
+  "bedAssignments": [
+    {
+      "bedId": "bed_001",
+      "assignedAt": "2026-05-01T07:00:00Z"
+    }
+  ],
+  "assignments": [
+    {
+      "bedId": "bed_001",
+      "assignedAt": "2026-05-01T07:00:00Z"
+    }
+  ],
+  "notes": "Main spring tomato sowing.",
+  "meta": {
+    "confidence": "exact"
+  }
+}

--- a/docs/contracts/samples/batch.tuber.canonical.json
+++ b/docs/contracts/samples/batch.tuber.canonical.json
@@ -1,0 +1,42 @@
+{
+  "batchId": "batch_potato_tuber_2026",
+  "cropId": "crop_potato",
+  "startedAt": "2026-03-22T09:15:00Z",
+  "propagationType": "tuber",
+  "startQuantity": {
+    "count": 12,
+    "unit": "seed_tubers"
+  },
+  "plantCountAlive": 11,
+  "stage": "sprouting",
+  "currentStage": "sprouting",
+  "stageEvents": [
+    {
+      "stage": "planted",
+      "occurredAt": "2026-03-22T09:15:00Z",
+      "method": "trench",
+      "meta": {
+        "confidence": "exact"
+      }
+    },
+    {
+      "stage": "sprouting",
+      "occurredAt": "2026-04-08T09:15:00Z",
+      "meta": {
+        "confidence": "estimated"
+      }
+    }
+  ],
+  "bedAssignments": [
+    {
+      "bedId": "bed_root_001",
+      "assignedAt": "2026-03-22T09:15:00Z"
+    }
+  ],
+  "assignments": [
+    {
+      "bedId": "bed_root_001",
+      "assignedAt": "2026-03-22T09:15:00Z"
+    }
+  ]
+}

--- a/docs/contracts/samples/crop.canonical.json
+++ b/docs/contracts/samples/crop.canonical.json
@@ -1,0 +1,17 @@
+{
+  "cropId": "crop_tomato",
+  "name": "Tomato",
+  "scientificName": "Solanum lycopersicum",
+  "taxonomy": {
+    "family": "Solanaceae",
+    "genus": "Solanum",
+    "species": "lycopersicum"
+  },
+  "aliases": [
+    "Garden Tomato"
+  ],
+  "isUserDefined": true,
+  "category": "fruiting",
+  "createdAt": "2026-01-10T09:00:00Z",
+  "updatedAt": "2026-02-01T09:00:00Z"
+}

--- a/docs/contracts/samples/task.canonical.json
+++ b/docs/contracts/samples/task.canonical.json
@@ -1,0 +1,18 @@
+{
+  "id": "task_plant_tomato_2026_05_01",
+  "sourceKey": "batch_tomato_seed_2026|2026-05-01|crop_tomato|bed_001|transplant",
+  "date": "2026-05-01",
+  "type": "transplant",
+  "cropId": "crop_tomato",
+  "bedId": "bed_001",
+  "batchId": "batch_tomato_seed_2026",
+  "checklist": [
+    {
+      "label": "Harden off seedlings"
+    },
+    {
+      "label": "Water in after transplant"
+    }
+  ],
+  "status": "open"
+}


### PR DESCRIPTION
### Motivation
- Provide a clear, implementable import/export contract for vNext so contributors and backends can implement payloads without reverse-engineering application code.
- Capture schema evolution notes for `Crop` and `Batch` and explicitly document legacy aliases and migration mappings to reduce ambiguity during migration.
- Ship minimal, realistic canonical payloads for common variants so implementers have validation-ready examples to follow.

### Description
- Add `docs/contracts/import-export-vnext.md` documenting canonical vNext import/export shape, migration mappings, propagation modeling rules, and confidence metadata guidance.
- Add minimal canonical JSON samples under `docs/contracts/samples/` for `crop.canonical.json`, `batch.seed.canonical.json`, `batch.regrow-runner.canonical.json`, `batch.tuber.canonical.json`, `task.canonical.json`, and `app-state.canonical.json` to illustrate real export payloads.
- Update `README.md` to reference the new contract guide and the sample payload location and to point implementers at the schema source-of-truth in `frontend/src/contracts`.
- This is a presentation-only change and does not modify domain logic, persistence, or scoring behavior; it documents current aliases and migration intent (e.g., `batch.stage` -> `batch.currentStage`).

### Testing
- No automated tests were run as part of this documentation-only patch; samples were authored to align with the existing JSON schemas in `frontend/src/contracts` but validation should be performed in CI or locally (for example via the repo's existing schema validators).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b172836f3c83269bff6fd9cfb1476d)