### PR TITLE
Support scientific-name-aware crop input resolution

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1227,6 +1227,8 @@ const formatCropOptionLabel = (crop: { cropId: string; name: string | undefined;
   return crop.name ?? crop.cropId;
 };
 
+const normalizeCropSearchValue = (value: string): string => value.trim().toLowerCase();
+
 const normalizeCropIdPart = (value: string): string =>
   value
     .toLowerCase()
@@ -1254,6 +1256,7 @@ function BatchesPage() {
   const [cropIds, setCropIds] = useState<string[]>([]);
   const [cropNames, setCropNames] = useState<Record<string, string>>({});
   const [cropScientificNames, setCropScientificNames] = useState<Record<string, string>>({});
+  const [cropAliases, setCropAliases] = useState<Record<string, string[]>>({});
   const [isLoading, setIsLoading] = useState(true);
   const [editingBatchId, setEditingBatchId] = useState<string | null>(null);
   const [formValues, setFormValues] = useState({
@@ -1281,6 +1284,7 @@ function BatchesPage() {
         setCropIds([]);
         setCropNames({});
         setCropScientificNames({});
+        setCropAliases({});
         setIsLoading(false);
         return;
       }
@@ -1293,6 +1297,16 @@ function BatchesPage() {
           appState.crops.map((crop) => {
             const scientificName = (crop as { scientificName?: string }).scientificName;
             return [crop.cropId, scientificName ?? ''];
+          }),
+        ),
+      );
+      setCropAliases(
+        Object.fromEntries(
+          appState.crops.map((crop) => {
+            const aliases = Array.isArray((crop as { aliases?: string[] }).aliases)
+              ? (crop as { aliases?: string[] }).aliases ?? []
+              : [];
+            return [crop.cropId, aliases];
           }),
         ),
       );
@@ -1352,9 +1366,12 @@ function BatchesPage() {
             name: cropNames[cropId],
             scientificName: cropScientificNames[cropId],
           }),
+          name: cropNames[cropId] ?? '',
+          scientificName: cropScientificNames[cropId] ?? '',
+          aliases: cropAliases[cropId] ?? [],
         }))
         .sort((left, right) => left.label.localeCompare(right.label)),
-    [cropIds, cropNames, cropScientificNames],
+    [cropAliases, cropIds, cropNames, cropScientificNames],
   );
 
   const filteredBatches = useMemo(
@@ -1401,17 +1418,34 @@ function BatchesPage() {
   };
 
   const resolveCropIdFromInput = (cropInput: string): string | null => {
-    const normalizedInput = cropInput.trim().toLowerCase();
+    const normalizedInput = normalizeCropSearchValue(cropInput);
     if (!normalizedInput) {
       return null;
     }
 
-    const match = cropInputOptions.find(
-      (option) =>
-        option.cropId.toLowerCase() === normalizedInput || option.label.toLowerCase() === normalizedInput,
-    );
+    const exactMatch = cropInputOptions.find((option) => {
+      const aliases = option.aliases.map((alias) => normalizeCropSearchValue(alias));
+      return (
+        normalizeCropSearchValue(option.cropId) === normalizedInput ||
+        normalizeCropSearchValue(option.label) === normalizedInput ||
+        normalizeCropSearchValue(option.name) === normalizedInput ||
+        normalizeCropSearchValue(option.scientificName) === normalizedInput ||
+        aliases.includes(normalizedInput)
+      );
+    });
 
-    return match?.cropId ?? null;
+    if (exactMatch) {
+      return exactMatch.cropId;
+    }
+
+    const containsMatch = cropInputOptions.find((option) => {
+      const searchFields = [option.cropId, option.name, option.scientificName, ...option.aliases]
+        .map((value) => normalizeCropSearchValue(value))
+        .filter(Boolean);
+      return searchFields.some((field) => field.includes(normalizedInput));
+    });
+
+    return containsMatch?.cropId ?? null;
   };
 
   const startEdit = (batch: Batch) => {


### PR DESCRIPTION
### Motivation
- Enable users to find crops by scientific name and aliases in the crop picker while preserving existing common-name behavior. 
- Include user-defined crops in search by using hydrated alias metadata from the app state.

### Description
- Added a lightweight normalizer `normalizeCropSearchValue` for consistent case-insensitive contains matching over search fields. 
- Hydrated `cropAliases` from `appState.crops` with null/undefined-safe handling and introduced `aliases` onto `cropInputOptions`. 
- Extended `resolveCropIdFromInput` to perform exact-match checks across `cropId`, display `label`, common `name`, `scientificName`, and `aliases`, and to fall back to a case-insensitive contains-based match over the same fields.

### Testing
- No automated tests or build/type-checks were executed as part of this fast patch; change is presentation/query-pipeline only and should be validated by the frontend test run or local manual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1911afd9c832686c86802e620adf3)