### PR TITLE
Exclude unsupported crops from nutrition aggregates and surface explicit warnings

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -369,13 +369,13 @@ describe('App', () => {
         return element?.tagName === 'LI' && text.includes('protein') && text.includes('total 1136 g') && text.includes('per day 3.11 g') && text.includes('coverage vs generic target: 6%');
       }),
     ).toBeInTheDocument();
-    expect(screen.getByText('Missing-data warning: none.')).toBeInTheDocument();
+    expect(screen.getByText('Excluded crops warning: none.')).toBeInTheDocument();
     expect(screen.getByText('Key micronutrients')).toBeInTheDocument();
     expect(screen.getByText(/coverage labels use generic targets only/i)).toBeInTheDocument();
     expect(screen.getByText(/Generic targets are for reference labels only and this estimate is rough/i)).toBeInTheDocument();
   });
 
-  it('flags plans with insufficient yield data in nutrition assumptions', async () => {
+  it('excludes crops with missing nutrition inputs and lists deterministic warning entries', async () => {
     vi.mocked(loadAppStateFromIndexedDb).mockResolvedValue({
       schemaVersion: 1,
       beds: [],
@@ -390,7 +390,38 @@ describe('App', () => {
         createdAt: '2026-01-01T00:00:00Z',
         updatedAt: '2026-01-01T00:00:00Z',
       },
-      crops: [],
+      crops: [
+        {
+          cropId: 'crop_unknown',
+          name: 'Mystery Crop',
+          companionsGood: [],
+          companionsAvoid: [],
+          rules: {
+            sowing: { sequence: 1, windows: [] },
+            transplant: { sequence: 2, windows: [] },
+            harvest: { sequence: 3, windows: [] },
+            storage: { sequence: 4, windows: [] },
+          },
+          nutritionProfile: [],
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+        {
+          cropId: 'crop_tomato',
+          name: 'Tomato',
+          companionsGood: [],
+          companionsAvoid: [],
+          rules: {
+            sowing: { sequence: 1, windows: [] },
+            transplant: { sequence: 2, windows: [] },
+            harvest: { sequence: 3, windows: [] },
+            storage: { sequence: 4, windows: [] },
+          },
+          nutritionProfile: [{ nutrient: 'kcal', value: 18, unit: 'kcal', source: 'USDA', assumptions: 'Per 100g edible portion.' }],
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      ],
       cropPlans: [
         {
           planId: 'plan_unknown',
@@ -398,6 +429,13 @@ describe('App', () => {
           seasonYear: 2026,
           plannedWindows: { sowing: [], harvest: [] },
           expectedYield: { amount: 12, unit: 'kg' },
+        },
+        {
+          planId: 'plan_tomato_missing_mass',
+          cropId: 'crop_tomato',
+          seasonYear: 2026,
+          plannedWindows: { sowing: [], harvest: [] },
+          expectedYield: { amount: 8, unit: 'pieces' },
         },
       ],
     } as never);
@@ -409,10 +447,11 @@ describe('App', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Missing-data warning')).toBeInTheDocument();
+      expect(screen.getByText('Excluded crops (missing nutrition data)')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('crop_unknown')).toBeInTheDocument();
+    expect(screen.getByText('Mystery Crop (plan_unknown) — missing nutrition profile')).toBeInTheDocument();
+    expect(screen.getByText('Tomato (plan_tomato_missing_mass) — missing mass expected yield')).toBeInTheDocument();
   });
 
   it('renders deterministic vegan nutrition flags with non-prescriptive language', async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2738,6 +2738,11 @@ const toYieldGrams = (plan: CropPlan): number | null => {
   return null;
 };
 
+const getNutritionPlanLabel = (plan: CropPlan, crop?: Crop): string => {
+  const baseName = crop?.name?.trim() ? crop.name : plan.cropId;
+  return `${baseName} (${plan.planId})`;
+};
+
 const summarizeNutrition = (cropPlans: CropPlan[], crops: Crop[]): NutritionSummary => {
   const cropById = new Map(crops.map((crop) => [crop.cropId, crop]));
   const totals = Object.fromEntries(NUTRITION_METRICS.map((metric) => [metric.key, 0])) as Record<string, number>;
@@ -2746,11 +2751,28 @@ const summarizeNutrition = (cropPlans: CropPlan[], crops: Crop[]): NutritionSumm
 
   for (const plan of cropPlans) {
     const crop = cropById.get(plan.cropId);
-    const yieldGrams = toYieldGrams(plan);
-    if (!crop || yieldGrams === null) {
-      excluded.add(crop?.name ?? plan.cropId);
+    const planLabel = getNutritionPlanLabel(plan, crop);
+
+    if (!crop || !crop.nutritionProfile || crop.nutritionProfile.length === 0) {
+      excluded.add(`${planLabel} — missing nutrition profile`);
       continue;
     }
+
+    const hasPerServingNutrition = crop.nutritionProfile.some((item) => item.assumptions.trim().toLowerCase().includes('per serving'));
+    if (hasPerServingNutrition) {
+      if (!plan.expectedYield || !Number.isFinite(plan.expectedYield.amount) || plan.expectedYield.amount <= 0 || plan.expectedYield.unit !== 'pieces') {
+        excluded.add(`${planLabel} — missing piece-based expected yield`);
+        continue;
+      }
+    } else {
+      const yieldGrams = toYieldGrams(plan);
+      if (yieldGrams === null) {
+        excluded.add(`${planLabel} — missing mass expected yield`);
+        continue;
+      }
+    }
+
+    const yieldGrams = toYieldGrams(plan);
 
     for (const item of crop.nutritionProfile) {
       if (!(item.nutrient in totals)) {
@@ -2761,13 +2783,8 @@ const summarizeNutrition = (cropPlans: CropPlan[], crops: Crop[]): NutritionSumm
       const perServing = assumptions.includes('per serving');
 
       if (perServing) {
-        if (plan.expectedYield.unit !== 'pieces') {
-          excluded.add(crop.name);
-          continue;
-        }
-
         totals[item.nutrient] = (totals[item.nutrient] ?? 0) + item.value * plan.expectedYield.amount;
-      } else {
+      } else if (yieldGrams !== null) {
         totals[item.nutrient] = (totals[item.nutrient] ?? 0) + (yieldGrams / 100) * item.value;
       }
 
@@ -2812,28 +2829,7 @@ function NutritionPage() {
   const macroMetrics = NUTRITION_METRICS.filter((metric) => ['kcal', 'protein', 'fat'].includes(metric.key));
   const microMetrics = NUTRITION_METRICS.filter((metric) => ['vitamin_c', 'vitamin_a', 'vitamin_k'].includes(metric.key));
   const flagsToShow = summary.flags.filter((flag) => flag.title.includes('B12') || flag.title.includes('Iodine'));
-  const missingDataWarnings = useMemo(() => {
-    const warnings = new Set(summary.excludedCrops);
-    const cropById = new Map(crops.map((crop) => [crop.cropId, crop]));
-
-    for (const plan of cropPlans) {
-      const crop = cropById.get(plan.cropId);
-      if (!crop) {
-        warnings.add(plan.cropId);
-        continue;
-      }
-
-      if (!crop.nutritionProfile || crop.nutritionProfile.length === 0) {
-        warnings.add(`${crop.name} (missing nutrition profile)`);
-      }
-
-      if (!plan.expectedYield || !Number.isFinite(plan.expectedYield.amount) || plan.expectedYield.amount <= 0) {
-        warnings.add(`${crop.name} (missing expected yield)`);
-      }
-    }
-
-    return [...warnings].sort((left, right) => left.localeCompare(right));
-  }, [cropPlans, crops, summary.excludedCrops]);
+  const missingNutritionWarnings = summary.excludedCrops;
 
   return (
     <section className="data-page">
@@ -2928,15 +2924,15 @@ function NutritionPage() {
               <li>Per serving entries require piece-based yield; otherwise crop is listed below.</li>
               <li>Rounding: kcal rounded to whole numbers, other nutrients rounded to 2 decimals.</li>
             </ul>
-            <h4>Missing-data warning</h4>
-            {missingDataWarnings.length > 0 ? (
+            <h4>Excluded crops (missing nutrition data)</h4>
+            {missingNutritionWarnings.length > 0 ? (
               <ul className="nutrition-warning-list">
-                {missingDataWarnings.map((name) => (
+                {missingNutritionWarnings.map((name) => (
                   <li key={name}>{name}</li>
                 ))}
               </ul>
             ) : (
-              <p className="nutrition-card-note">Missing-data warning: none.</p>
+              <p className="nutrition-card-note">Excluded crops warning: none.</p>
             )}
           </article>
 


### PR DESCRIPTION
### Motivation
- Nutrition aggregates could be silently distorted or crash when crop nutrition inputs or expected yields are missing, so unsupported crop plans must be excluded from totals. 
- Exclusions must be deterministic and human-readable to preserve user trust in aggregate totals. 
- The UI should surface which crop plans were omitted and why so missing-data posture is explicit, not silent.

### Description
- Update aggregation: `summarizeNutrition` now skips plans that lack a `nutritionProfile` or the required expected-yield format (mass for per-100g entries, pieces for per-serving entries) and records deterministic, human-readable exclusion messages; added `getNutritionPlanLabel` to emit `name (planId)` labels. (changed `frontend/src/App.tsx`)
- UI change: Nutrition page now reads and renders the aggregation `excludedCrops` payload under the heading `Excluded crops (missing nutrition data)` and updated copy for the no-warning state. (changed `frontend/src/App.tsx`)
- Tests: updated the nutrition-related unit tests to assert the new exclusion heading/copy and deterministic exclusion list entries for mixed complete/incomplete inputs. (changed `frontend/src/App.test.tsx`)

### Testing
- Unit tests updated: `frontend/src/App.test.tsx` now contains assertions for deterministic totals plus exclusion warning entries. 
- No automated test suite was executed in this environment; tests should be run in CI or locally (`npm test` / `pnpm test`) to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e2e045dc83269f4ae713b0a694c3)