### PR TITLE
Support partial crop metadata in contracts and repository flows

### DIFF
--- a/frontend/src/contracts/crop.schema.json
+++ b/frontend/src/contracts/crop.schema.json
@@ -8,6 +8,36 @@
     "createdAt",
     "updatedAt"
   ],
+  "allOf": [
+    {
+      "anyOf": [
+        {
+          "required": [
+            "cropId"
+          ]
+        },
+        {
+          "required": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "anyOf": [
+        {
+          "required": [
+            "name"
+          ]
+        },
+        {
+          "required": [
+            "commonName"
+          ]
+        }
+      ]
+    }
+  ],
   "properties": {
     "cropId": {
       "$ref": "#/$defs/id"
@@ -65,16 +95,14 @@
       "items": {
         "$ref": "#/$defs/id"
       },
-      "uniqueItems": true,
-      "default": []
+      "uniqueItems": true
     },
     "companionsAvoid": {
       "type": "array",
       "items": {
         "$ref": "#/$defs/id"
       },
-      "uniqueItems": true,
-      "default": []
+      "uniqueItems": true
     },
     "rules": {
       "type": "object",
@@ -105,8 +133,7 @@
       "type": "array",
       "items": {
         "$ref": "#/$defs/nutritionItem"
-      },
-      "default": []
+      }
     },
     "createdAt": {
       "$ref": "#/$defs/isoDate"

--- a/frontend/src/contracts/crop.schema.test.ts
+++ b/frontend/src/contracts/crop.schema.test.ts
@@ -73,10 +73,23 @@ describe('crop.schema.json', () => {
   });
 
   it('rejects payloads missing required fields', () => {
-    const { cropId, ...payload } = validPayload;
+    const { cropId, name, ...payload } = validPayload;
 
     expect(cropId).toBeDefined();
+    expect(name).toBeDefined();
     expect(validate(payload)).toBe(false);
+  });
+
+
+  it('accepts partial crop payloads with minimal identity only', () => {
+    const payload = {
+      cropId: 'crop_partial',
+      name: 'Partial Crop',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+
+    expect(validate(payload)).toBe(true);
   });
 
 

--- a/frontend/src/data/validation/index.test.ts
+++ b/frontend/src/data/validation/index.test.ts
@@ -143,6 +143,13 @@ const validCrop = {
   updatedAt: '2024-01-02T00:00:00Z',
 };
 
+const validPartialCrop = {
+  cropId: 'crop-partial',
+  name: 'Partial Crop',
+  createdAt: '2024-01-03T00:00:00Z',
+  updatedAt: '2024-01-03T00:00:00Z',
+};
+
 const validCropPlan = {
   planId: 'plan-1',
   cropId: 'crop-1',
@@ -651,6 +658,21 @@ describe('crop repository boundary helpers', () => {
 
     const removed = removeCropFromAppState(upserted, validCrop.cropId);
     expect(getCropFromAppState(removed, validCrop.cropId)).toBeNull();
+  });
+
+  it('accepts partial crops without rules, nutrition, or companions', () => {
+    const upserted = upsertCropInAppState(validAppState, validPartialCrop);
+
+    expect(getCropFromAppState(upserted, validPartialCrop.cropId)).toEqual(validPartialCrop);
+    expect(listCropsFromAppState(upserted)).toContainEqual(validPartialCrop);
+  });
+
+  it('roundtrips partial crops through export/import', () => {
+    const stateWithPartialCrop = upsertCropInAppState(validAppState, validPartialCrop);
+    const exported = serializeAppStateForExport(stateWithPartialCrop);
+    const imported = parseImportedAppState(exported);
+
+    expect(getCropFromAppState(imported, validPartialCrop.cropId)).toEqual(validPartialCrop);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Allow user-created crops to be persisted with only essential identity fields while keeping advanced metadata optional.
- Prevent repository/import/export from fabricating empty arrays or coercing missing optional metadata into present placeholders.
- Preserve backward compatibility for fully-defined crop records and keep domain logic unchanged.

### Description
- Relaxed the `Crop` contract in `frontend/src/contracts/crop.schema.json` to require only timestamps plus either `cropId`/`id` and either `name`/`commonName`, and removed `default: []` for optional companion and nutrition arrays. 
- Added a positive contract test for minimal identity-only payloads in `frontend/src/contracts/crop.schema.test.ts`.
- Added repository/import/export boundary tests that upsert a partial crop and verify save/load and export/import roundtrips in `frontend/src/data/validation/index.test.ts`.
- No domain/persistence/scoring logic was changed; only contract validation and tests were updated.

### Testing
- No automated test suite was executed as part of this patch; changes include updated/added tests that should be run locally or in CI. 
- Updated/added automated tests: `frontend/src/contracts/crop.schema.test.ts` (new minimal payload case) and `frontend/src/data/validation/index.test.ts` (upsert/roundtrip partial crop tests). 
- Recommend running `pnpm --filter frontend test` locally or in CI to validate the test suite after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e4f8a8d08326ae7fdaa5a7720087)