### PR TITLE
docs: align .NET readiness and import-export vNext docs with finalized schema

### DIFF
--- a/docs/contracts/import-export-vnext.md
+++ b/docs/contracts/import-export-vnext.md
@@ -28,6 +28,8 @@ Canonical samples:
 
 - Canonical vNext payloads use `AppState.schemaVersion = 2`.
 - Crop now supports richer metadata (`scientificName`, `taxonomy`, `aliases`, `isUserDefined`).
+- Crop also supports **partial records** for staged data entry/sync: only identity (`cropId` or `id`, `name` or `commonName`) plus timestamps are required.
+- `rules`, `taskRules`, and `nutritionProfile` are optional and may be omitted for user-defined crops.
 - Batch modeling shifts from implicit nested legacy structures to explicit event/quantity fields:
   - timeline in `stageEvents`
   - placement in `bedAssignments`
@@ -123,6 +125,26 @@ After (canonical export):
 }
 ```
 
+### 3) Partial user-defined crop (canonical)
+
+```json
+{
+  "cropId": "crop_user_herb_mix",
+  "name": "Herb Mix",
+  "isUserDefined": true,
+  "aliases": ["Kitchen Herb Mix", "Mixed Herbs"],
+  "scientificName": "Mentha spp. blend",
+  "createdAt": "2026-01-15T10:00:00Z",
+  "updatedAt": "2026-01-15T10:00:00Z"
+}
+```
+
+Behavior note:
+
+- If `rules`/`taskRules` are omitted, calendar/task derivation should treat the crop as "no schedule metadata available" and skip rule-driven task generation for that crop.
+- If `nutritionProfile` is omitted, nutrition rollups should ignore crop-level nutrient contribution rather than failing validation/import.
+- Do not over-validate user-defined crops beyond schema requirements.
+
 ## Propagation modeling rules
 
 ### When to use `startQuantity`
@@ -154,6 +176,19 @@ Use `meta.confidence` / `stageEvents[].meta.confidence` when the value quality m
 - `exact`
 - `estimated`
 - `unknown`
+
+## Backend/C# mapping notes (contract-preserving)
+
+- Keep JSON Schema canonical while backend stabilizes; C# DTOs should map 1:1 to schema fields.
+- Preserve legacy alias read-support during import (`id`, `commonName`, `stage`, `assignments`), but emit canonical names on export.
+- Recommended C# handling for crop identity/metadata:
+  - `CropId = crop.cropId ?? crop.id`
+  - `Name = crop.name ?? crop.commonName`
+  - Map `ScientificName` and `Aliases` as optional values (nullable string + collection).
+- Recommended C# handling for batch timeline/state:
+  - Require persisted `StartedAt`, `StageEvents`, and legacy-required `Stage` + `Assignments` until schema requirement changes.
+  - Compute/validate `CurrentStage` from latest `StageEvents[*].Stage` when absent.
+  - Keep alias parity between `bedAssignments` and `assignments` in write paths until migration-only aliases are formally removed.
 
 ## Minimal canonical payload set
 

--- a/docs/dotnet-readiness.md
+++ b/docs/dotnet-readiness.md
@@ -34,6 +34,7 @@ If any criterion is unmet, stay JSON Schema-first.
 
 - Domain entities/value objects mirror schema-generated records:
   - `Bed`, `Crop`, `CropPlan`, `Batch`, `Task`, `SeedInventoryItem`, `Settings`, plus aggregate `AppState`.
+- Crop ingest must accept minimal/partial crop payloads (identity + timestamps) so user-defined crops can exist before full rule/nutrition metadata is available.
 - Domain services host business rules currently used by TS logic (task derivation windows, stage transitions, status changes, etc.).
 - Domain layer has no HTTP, storage, or UI dependencies.
 
@@ -45,6 +46,7 @@ If any criterion is unmet, stay JSON Schema-first.
   - `ListTasksByDateAndStatus`
   - `SaveSettings`, etc.
 - DTOs stay schema-aligned to avoid adapter bloat.
+- Avoid backend-side over-validation for optional crop metadata (`rules`, `taskRules`, `nutritionProfile`, `scientificName`, `aliases`, `taxonomy`).
 
 ### Persistence layer (HTTP + storage adapters)
 
@@ -152,6 +154,7 @@ Example `GET /api/crop-plans?cropId=crop_potato&seasonYear=2026` response item:
 Batch timeline canonicalization (vNext):
 
 - Canonical export does not include a separate required `start` object; start semantics are represented by `startedAt` + `stageEvents[0]`.
+- Current schema still requires legacy `stage` + `assignments`; backend should continue dual-field writes (`currentStage` + `stage`, `bedAssignments` + `assignments`) until alias removal is finalized.
 - Mapping from legacy `start.*`:
   - `start.date` -> `startedAt` and `stageEvents[0].occurredAt`
   - `start.stage` -> `stageEvents[0].stage` and `currentStage` when no later stage events exist
@@ -279,3 +282,61 @@ If either language fails parity, block release.
 - Agreed endpoint naming and filter semantics for repository parity.
 - Golden vector ownership/versioning documented and enforced.
 - Initial CI gate draft covers schema conformance + parity checks.
+
+
+## C# mapping examples for finalized vNext contracts
+
+### Crop mapping (aliases + optional metadata)
+
+```csharp
+public sealed record CropDto(
+    string? cropId,
+    string? id,
+    string? name,
+    string? commonName,
+    string? scientificName,
+    IReadOnlyList<string>? aliases,
+    bool? isUserDefined,
+    object? rules,
+    IReadOnlyList<object>? taskRules,
+    IReadOnlyList<object>? nutritionProfile,
+    DateTimeOffset createdAt,
+    DateTimeOffset updatedAt
+);
+
+var canonicalCropId = dto.cropId ?? dto.id
+    ?? throw new ValidationException("cropId/id required");
+var canonicalName = dto.name ?? dto.commonName
+    ?? throw new ValidationException("name/commonName required");
+
+// Optional metadata stays nullable/empty to support partial user-defined crops.
+var scientificName = dto.scientificName;
+var aliases = dto.aliases ?? Array.Empty<string>();
+```
+
+### Batch mapping (canonical timeline + legacy parity fields)
+
+```csharp
+public sealed record BatchDto(
+    string batchId,
+    string cropId,
+    DateTimeOffset startedAt,
+    string stage,
+    string? currentStage,
+    IReadOnlyList<StageEventDto> stageEvents,
+    IReadOnlyList<BedAssignmentDto> assignments,
+    IReadOnlyList<BedAssignmentDto>? bedAssignments
+);
+
+var canonicalAssignments = dto.bedAssignments ?? dto.assignments;
+var canonicalCurrentStage = dto.currentStage
+    ?? dto.stageEvents[^1].stage;
+
+// While aliases remain required in schema, write both canonical + alias fields.
+```
+
+### Optional rules behavior in processing pipelines
+
+- Calendar/task processors should short-circuit rule-derived task generation when crop `rules`/`taskRules` are absent.
+- Nutrition processors should skip crop-level nutrition contribution when `nutritionProfile` is absent.
+- Missing optional metadata is a valid contract state, not a backend validation error.


### PR DESCRIPTION
### Motivation
- Ensure backend implementers can proceed without reverse-engineering frontend assumptions by updating readiness docs to match the finalized vNext schema and contract behavior. 
- Clarify optional/partial crop support so user-defined crops can be ingested without full `rules`/`taskRules`/`nutritionProfile` metadata. 
- Provide explicit C# mapping guidance and alias-parity notes to reduce divergence and avoid backend over-validation while migration aliases remain accepted.

### Description
- Updated `docs/contracts/import-export-vnext.md` to document partial/user-defined crop support, add a canonical partial crop example, and explain `rules`/`taskRules`/`nutritionProfile` optionality and processing implications. 
- Added backend/C# mapping notes in `docs/contracts/import-export-vnext.md` describing alias read-support (`id`, `commonName`, `stage`, `assignments`) and recommended 1:1 DTO mapping and canonicalization examples (`CropId = crop.cropId ?? crop.id`, `Name = crop.name ?? crop.commonName`). 
- Updated `docs/dotnet-readiness.md` to instruct .NET implementers to accept minimal crop payloads, avoid over-validation of optional metadata, and to continue dual-field writes for batch parity (`currentStage` + `stage`, `bedAssignments` + `assignments`) until aliases are removed. 
- Added concrete C# mapping snippets for `CropDto` and `BatchDto` plus guidance for `currentStage` derivation and pipeline behavior when optional rules/nutrition are missing.

### Testing
- No automated tests were run because this is a documentation-only change and does not alter runtime behavior. 
- Documentation updates were validated by inspecting the updated files to ensure the new guidance and examples were added as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c556b8008326a8c06737431f99c0)